### PR TITLE
Remove references to Simfony

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -219,7 +219,7 @@ checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 name = "codegen"
 version = "0.1.0"
 dependencies = [
- "simfony",
+ "simplicityhl",
 ]
 
 [[package]]
@@ -621,24 +621,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "simfony"
-version = "0.1.0"
-dependencies = [
- "arbitrary",
- "base64",
- "clap",
- "either",
- "getrandom",
- "itertools",
- "miniscript",
- "pest",
- "pest_derive",
- "serde",
- "serde_json",
- "simplicity-lang",
-]
-
-[[package]]
 name = "simplicity-lang"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -663,6 +645,24 @@ checksum = "e9c453a3edfff1ca89b03616a0028f5dc0da0ac5099665ee63357561edf1db71"
 dependencies = [
  "bitcoin_hashes",
  "cc",
+]
+
+[[package]]
+name = "simplicityhl"
+version = "0.1.0"
+dependencies = [
+ "arbitrary",
+ "base64",
+ "clap",
+ "either",
+ "getrandom",
+ "itertools",
+ "miniscript",
+ "pest",
+ "pest_derive",
+ "serde",
+ "serde_json",
+ "simplicity-lang",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,16 +1,16 @@
 [package]
-name = "simfony"
+name = "simplicityhl"
 version = "0.1.0"
 authors = ["sanket1729 <sanket1729@gmail.com>"]
 license = "CC0-1.0"
-homepage = "https://github.com/BlockstreamResearch/simfony/"
-repository = "https://github.com/BlockstreamResearch/simfony/"
+homepage = "https://github.com/BlockstreamResearch/SimplicityHL"
+repository = "https://github.com/BlockstreamResearch/SimplicityHL"
 description = "Rust-like language that compiles to Simplicity bytecode."
 edition = "2021"
 rust-version = "1.78.0"
 
 [lib]
-name = "simfony"
+name = "simplicityhl"
 path = "src/lib.rs"
 
 [[bin]]

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-Simfony is a high-level language for writing Bitcoin smart contracts.
+SimplicityHL is a high-level language for writing Bitcoin smart contracts.
 
-Simfony looks and feels like [Rust](https://www.rust-lang.org). Just how Rust compiles down to assembly language, Simfony compiles down to [Simplicity](https://github.com/BlockstreamResearch/simplicity) bytecode. Developers write Simfony, full nodes execute Simplicity.
+SimplicityHL looks and feels like [Rust](https://www.rust-lang.org). Just how Rust compiles down to assembly language, SimplicityHL compiles down to [Simplicity](https://github.com/BlockstreamResearch/simplicity) bytecode. Developers write SimplicityHL, full nodes execute Simplicity.
 
-**Simfony is a work in progress and is not yet ready for production use.**
+**SimplicityHL is a work in progress and is not yet ready for production use.**
 
 ```rust
 let a: u32 = 10;
@@ -16,7 +16,7 @@ let b = {
 assert!(jet::eq_32(b, 7));
 ```
 
-Take a look at the [example programs](https://github.com/BlockstreamResearch/simfony/tree/master/examples).
+Take a look at the [example programs](https://github.com/BlockstreamResearch/SimplicityHL/tree/master/examples).
 
 ## MSRV
 
@@ -24,30 +24,30 @@ This crate should compile with any feature combination on **Rust 1.78.0** or hig
 
 ## Simplicity's need for a high-level language
 
-Simplicity introduces a groundbreaking low-level programming language and machine model meticulously crafted for blockchain-based smart contracts. The primary goal is to provide a streamlined and comprehensible foundation that facilitates static analysis and encourages reasoning through formal methods. While the elegance of the language itself is distilled into something as succinct as fitting onto a T-shirt, it's important to note that the simplicity of the language doesn't directly equate to simplicity in the development process. Simfony revolves around demystifying and simplifying the complexities involved in this ecosystem.
+Simplicity introduces a groundbreaking low-level programming language and machine model meticulously crafted for blockchain-based smart contracts. The primary goal is to provide a streamlined and comprehensible foundation that facilitates static analysis and encourages reasoning through formal methods. While the elegance of the language itself is distilled into something as succinct as fitting onto a T-shirt, it's important to note that the simplicity of the language doesn't directly equate to simplicity in the development process. SimplicityHL revolves around demystifying and simplifying the complexities involved in this ecosystem.
 
 The distinguishing aspects that set Simplicity apart from conventional programming languages are:
 
 - **Distinct Programming Paradigm**: Simplicity's programming model requires a paradigm shift from conventional programming. It hinges on reasoning about programs in a functional sense with a focus on combinators. This intricacy surpasses even popular functional languages like Haskell, with its own unique challenges.
 - **Exceptional Low-Level Nature**: Unlike high-level languages such as JavaScript or Python, Simplicity operates at an extremely low level, resembling assembly languages. This design choice enables easier reasoning about the formal semantics of programs, but is really work on directly.
 
-## Simfony
+## SimplicityHL
 
-Simfony is a high-level language that compiles to Simplicity. It maps programming concepts from Simplicity onto programming concepts that developers are more familar with. In particular, Rust is a popular language whose functional aspects fit Simplicity well. Simfony aims to closely resemble Rust.
+SimplicityHL is a high-level language that compiles to Simplicity. It maps programming concepts from Simplicity onto programming concepts that developers are more familar with. In particular, Rust is a popular language whose functional aspects fit Simplicity well. SimplicityHL aims to closely resemble Rust.
 
-Just how Rust is compiled to assembly language, Simfony is compiled to Simplicity. Just how writing Rust doesn't necessarily produce the most efficient assembly, writing Simfony doesn't necessarily produce the most efficient Simplicity code. The compilers try to optimize the target code they produce, but manually written target code can be more efficient. On the other hand, a compiled language is much easier to read, write and reason about. Assembly is meant to be consumed by machines while Rust is meant to be consumed by humans. Simplicity is meant to be consumed by Bitcoin full nodes while Simfony is meant to be consumed by Bitcoin developers.
+Just how Rust is compiled to assembly language, SimplicityHL is compiled to Simplicity. Just how writing Rust doesn't necessarily produce the most efficient assembly, writing SimplicityHL doesn't necessarily produce the most efficient Simplicity code. The compilers try to optimize the target code they produce, but manually written target code can be more efficient. On the other hand, a compiled language is much easier to read, write and reason about. Assembly is meant to be consumed by machines while Rust is meant to be consumed by humans. Simplicity is meant to be consumed by Bitcoin full nodes while SimplicityHL is meant to be consumed by Bitcoin developers.
 
 ## Installation
 
-Clone the repo and build the Simfony compiler using cargo.
+Clone the repo and build the SimplicityHL compiler using cargo.
 
 ```bash
-git clone https://github.com/BlockstreamResearch/simfony.git
-cd simfony
+git clone https://github.com/BlockstreamResearch/SimplicityHL.git
+cd SimplicityHL
 cargo build
 ```
 
-Optionally, install the Simfony compiler using cargo.
+Optionally, install the SimplicityHL compiler using cargo.
 
 ```bash
 cargo install --path .
@@ -55,10 +55,10 @@ cargo install --path .
 
 ## Usage
 
-The Simfony compiler takes two arguments:
+The SimplicityHL compiler takes two arguments:
 
-1. A path to a Simfony program file (`.simf`)
-1. A path to a Simfony witness file (`.wit`, optional)
+1. A path to a SimplicityHL program file (`.simf`)
+1. A path to a SimplicityHL witness file (`.wit`, optional)
 
 The compiler produces a base64-encoded Simplicity program. Witness data will be included if a witness file is provided.
 

--- a/bitcoind-tests/Cargo.lock
+++ b/bitcoind-tests/Cargo.lock
@@ -155,7 +155,7 @@ dependencies = [
  "elementsd",
  "rand",
  "secp256k1",
- "simfony",
+ "simplicityhl",
 ]
 
 [[package]]
@@ -693,7 +693,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "simfony"
+name = "simplicityhl"
 version = "0.1.0"
 dependencies = [
  "base64 0.21.2",

--- a/bitcoind-tests/Cargo.toml
+++ b/bitcoind-tests/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["sanket1729 <sanket1729@gmail.com>"]
 edition = "2021"
 
 [dependencies]
-simfony = { path = ".." }
+simplicityhl = { path = ".." }
 elementsd = { version = "0.11.0" }
 actual-rand = { package = "rand", version = "0.8.4" }
 secp256k1 = { version = "0.29.0", features = ["rand-std"] }

--- a/bitcoind-tests/tests/common/daemon.rs
+++ b/bitcoind-tests/tests/common/daemon.rs
@@ -5,7 +5,7 @@ use elements::hex::FromHex;
 use elementsd::bitcoincore_rpc::jsonrpc::serde_json::{json, Value};
 use elementsd::bitcoind::bitcoincore_rpc::RpcApi;
 use elementsd::ElementsD;
-use simfony::elements;
+use simplicityhl::elements;
 
 // We are not using pegins right now, but it might be required in case in future
 // if we extend the tests to check pegins etc.

--- a/bitcoind-tests/tests/common/test.rs
+++ b/bitcoind-tests/tests/common/test.rs
@@ -5,18 +5,18 @@ use elements::pset::PartiallySignedTransaction as Psbt;
 use elements::{confidential, secp256k1_zkp as secp256k1};
 use elementsd::ElementsD;
 use secp256k1::XOnlyPublicKey;
-use simfony::{elements, simplicity};
 use simplicity::jet::elements::{ElementsEnv, ElementsUtxo};
+use simplicityhl::{elements, simplicity};
 
 use crate::common::daemon::Call;
 
-type FnWitness = fn([u8; 32]) -> simfony::WitnessValues;
+type FnWitness = fn([u8; 32]) -> simplicityhl::WitnessValues;
 
 #[derive(Clone)]
 pub struct TestCase<'a> {
     pub name: &'static str,
-    template: Option<simfony::TemplateProgram>,
-    compiled: Option<simfony::CompiledProgram>,
+    template: Option<simplicityhl::TemplateProgram>,
+    compiled: Option<simplicityhl::CompiledProgram>,
     witness: FnWitness,
     lock_time: elements::LockTime,
     sequence: elements::Sequence,
@@ -53,7 +53,7 @@ impl<'a> TestCase<'a> {
 
     pub fn program_path<P: AsRef<std::path::Path>>(mut self, path: P) -> Self {
         let text = std::fs::read_to_string(path).expect("path should be readable");
-        let compiled = simfony::CompiledProgram::new(text.as_str(), simfony::Arguments::default(), false)
+        let compiled = simplicityhl::CompiledProgram::new(text.as_str(), simplicityhl::Arguments::default(), false)
             .expect("program should compile");
         self.compiled = Some(compiled);
         self
@@ -62,12 +62,12 @@ impl<'a> TestCase<'a> {
     pub fn template_path<P: AsRef<std::path::Path>>(mut self, path: P) -> Self {
         let text = std::fs::read_to_string(path).expect("path should be readable");
         let template =
-            simfony::TemplateProgram::new(text.as_str()).expect("program should compile");
+            simplicityhl::TemplateProgram::new(text.as_str()).expect("program should compile");
         self.template = Some(template);
         self
     }
 
-    pub fn arguments(mut self, arguments: simfony::Arguments) -> Self {
+    pub fn arguments(mut self, arguments: simplicityhl::Arguments) -> Self {
         let compiled = self
             .template
             .as_ref()
@@ -220,6 +220,6 @@ impl<'a> TestCase<'a> {
     }
 }
 
-fn empty_witness(_sighash_all: [u8; 32]) -> simfony::WitnessValues {
-    simfony::WitnessValues::default()
+fn empty_witness(_sighash_all: [u8; 32]) -> simplicityhl::WitnessValues {
+    simplicityhl::WitnessValues::default()
 }

--- a/bitcoind-tests/tests/common/util.rs
+++ b/bitcoind-tests/tests/common/util.rs
@@ -11,8 +11,8 @@ pub fn sign_schnorr(secret_key: u32, message: [u8; 32]) -> [u8; 64] {
     key_pair.sign_schnorr(message).serialize()
 }
 
-pub fn xonly_public_key(secret_key: u32) -> simfony::num::U256 {
+pub fn xonly_public_key(secret_key: u32) -> simplicityhl::num::U256 {
     let key_pair = key_pair(secret_key);
     let bytes = key_pair.x_only_public_key().0.serialize();
-    simfony::num::U256::from_byte_array(bytes)
+    simplicityhl::num::U256::from_byte_array(bytes)
 }

--- a/bitcoind-tests/tests/spend_utxo.rs
+++ b/bitcoind-tests/tests/spend_utxo.rs
@@ -3,10 +3,10 @@ use std::collections::HashMap;
 use elements::hashes::Hash;
 use elements::secp256k1_zkp as secp256k1;
 use secp256k1::hashes::{sha256, HashEngine};
-use simfony::str::WitnessName;
-use simfony::types::TypeConstructible;
-use simfony::value::ValueConstructible;
-use simfony::{elements, ResolvedType, Value};
+use simplicityhl::str::WitnessName;
+use simplicityhl::types::TypeConstructible;
+use simplicityhl::value::ValueConstructible;
+use simplicityhl::{elements, ResolvedType, Value};
 
 mod common;
 use common::daemon::{self, Call};
@@ -49,7 +49,7 @@ fn spend_utxo() {
     }
 }
 
-fn hodl_vault(sighash_all: [u8; 32]) -> simfony::WitnessValues {
+fn hodl_vault(sighash_all: [u8; 32]) -> simplicityhl::WitnessValues {
     let mut witness_values = HashMap::new();
     let oracle_height = 1000;
     witness_values.insert(
@@ -73,24 +73,24 @@ fn hodl_vault(sighash_all: [u8; 32]) -> simfony::WitnessValues {
         WitnessName::from_str_unchecked("OWNER_SIG"),
         Value::byte_array(util::sign_schnorr(2, sighash_all)),
     );
-    simfony::WitnessValues::from(witness_values)
+    simplicityhl::WitnessValues::from(witness_values)
 }
 
-fn p2pk_args() -> simfony::Arguments {
-    simfony::Arguments::from(HashMap::from([(
+fn p2pk_args() -> simplicityhl::Arguments {
+    simplicityhl::Arguments::from(HashMap::from([(
         WitnessName::from_str_unchecked("ALICE_PUBLIC_KEY"),
         Value::u256(util::xonly_public_key(1)),
     )]))
 }
 
-fn p2pk(sighash_all: [u8; 32]) -> simfony::WitnessValues {
-    simfony::WitnessValues::from(HashMap::from([(
+fn p2pk(sighash_all: [u8; 32]) -> simplicityhl::WitnessValues {
+    simplicityhl::WitnessValues::from(HashMap::from([(
         WitnessName::from_str_unchecked("ALICE_SIGNATURE"),
         Value::byte_array(util::sign_schnorr(1, sighash_all)),
     )]))
 }
 
-fn p2pkh(sighash_all: [u8; 32]) -> simfony::WitnessValues {
+fn p2pkh(sighash_all: [u8; 32]) -> simplicityhl::WitnessValues {
     let mut witness_values = HashMap::new();
     witness_values.insert(
         WitnessName::from_str_unchecked("PK"),
@@ -100,10 +100,10 @@ fn p2pkh(sighash_all: [u8; 32]) -> simfony::WitnessValues {
         WitnessName::from_str_unchecked("SIG"),
         Value::byte_array(util::sign_schnorr(1, sighash_all)),
     );
-    simfony::WitnessValues::from(witness_values)
+    simplicityhl::WitnessValues::from(witness_values)
 }
 
-fn p2ms(sighash_all: [u8; 32]) -> simfony::WitnessValues {
+fn p2ms(sighash_all: [u8; 32]) -> simplicityhl::WitnessValues {
     let mut witness_values = HashMap::new();
     let sig1 = Value::some(Value::byte_array(util::sign_schnorr(1, sighash_all)));
     let sig2 = Value::none(ResolvedType::byte_array(64));
@@ -111,5 +111,5 @@ fn p2ms(sighash_all: [u8; 32]) -> simfony::WitnessValues {
     let ty = sig1.ty().clone();
     let maybe_sigs = Value::array([sig1, sig2, sig3], ty);
     witness_values.insert(WitnessName::from_str_unchecked("MAYBE_SIGS"), maybe_sigs);
-    simfony::WitnessValues::from(witness_values)
+    simplicityhl::WitnessValues::from(witness_values)
 }

--- a/book/book.toml
+++ b/book/book.toml
@@ -3,4 +3,4 @@ authors = ["Christian Lewe"]
 language = "en"
 multilingual = false
 src = "src"
-title = "The Simfony Programming Language"
+title = "The SimplicityHL Programming Language"

--- a/book/src/function.md
+++ b/book/src/function.md
@@ -31,12 +31,12 @@ let z: u32 = add(40, 2);
 
 ## No early returns
 
-Simfony has no support for an early return via a "return" keyword.
+SimplicityHL has no support for an early return via a "return" keyword.
 The only branching that is available is via [match expressions](./match_expression.md).
 
 ## No recursion
 
-Simfony has no support for recursive function calls.
+SimplicityHL has no support for recursive function calls.
 A function can be called inside a function body if it has been defined before.
 This means that a function cannot call itself.
 Loops, where `f` calls `g` and `g` calls `f`, are also impossible.
@@ -75,7 +75,7 @@ fn g() -> u32 {
 
 ## Main function
 
-The `main` function is the entry point of each Simfony program.
+The `main` function is the entry point of each SimplicityHL program.
 Running a program means running its `main` function.
 Other functions are called from the `main` function.
 
@@ -86,7 +86,7 @@ fn main() {
 ```
 
 The `main` function is a reserved name and must exist in every program.
-Simfony programs are always "binaries".
+SimplicityHL programs are always "binaries".
 There is no support for "libraries".
 
 ## Jets

--- a/book/src/introduction.md
+++ b/book/src/introduction.md
@@ -1,7 +1,7 @@
 # Introduction
 
-Simfony is a high-level language for writing Bitcoin smart contracts.
-In other words, Simfony is a language for expressing spending conditions of UTXOs on the Bitcoin blockchain.
+SimplicityHL is a high-level language for writing Bitcoin smart contracts.
+In other words, SimplicityHL is a language for expressing spending conditions of UTXOs on the Bitcoin blockchain.
 
-Simfony looks and feels like [Rust](https://www.rust-lang.org/).
-Developers write Simfony, Bitcoin full nodes run Simplicity.
+SimplicityHL looks and feels like [Rust](https://www.rust-lang.org/).
+Developers write SimplicityHL, Bitcoin full nodes run Simplicity.

--- a/book/src/let_statement.md
+++ b/book/src/let_statement.md
@@ -17,12 +17,12 @@ Variables can be assigned to the output value of any expression, such as functio
 
 ## Explicit typing
 
-In Simfony, the type of a defined variable **always** has to be written.
+In SimplicityHL, the type of a defined variable **always** has to be written.
 This is different from Rust, which has better type inference.
 
 ## Immutability
 
-Simfony variables are **always** immutable.
+SimplicityHL variables are **always** immutable.
 There are no mutable variables.
 
 ## Redefinition and scoping

--- a/book/src/match_expression.md
+++ b/book/src/match_expression.md
@@ -21,7 +21,7 @@ The whole match expression returns a value of type `u32`, from one of the two ar
 
 ## Explicit typing
 
-In Simfony, the type of variables inside match arms must **always** be written.
+In SimplicityHL, the type of variables inside match arms must **always** be written.
 This is different from Rust, which has better type inference.
 
 ## Pattern matching
@@ -29,7 +29,7 @@ This is different from Rust, which has better type inference.
 There is limited support for pattern matching inside match expressions.
 
 Boolean values can be matched.
-The Boolean match expression is the replacement for an "if-then-else" in Simfony.
+The Boolean match expression is the replacement for an "if-then-else" in SimplicityHL.
 
 ```rust
 let bit_flip: bool = match false {

--- a/book/src/program.md
+++ b/book/src/program.md
@@ -1,6 +1,6 @@
 # Programs
 
-A Simfony program consists of a `main` [function](./function.md).
+A SimplicityHL program consists of a `main` [function](./function.md).
 
 A program may also have [type aliases](./type_alias.md) or custom [function definitions](./function.md).
 The `main` function comes last in the program, because everything it calls must be defined before it.

--- a/book/src/type.md
+++ b/book/src/type.md
@@ -1,6 +1,6 @@
 # Types and Values
 
-Simfony mostly uses a subset of Rust's types.
+SimplicityHL mostly uses a subset of Rust's types.
 It extends Rust in some ways to make it work better with Simplicity and with the blockchain.
 
 ## Boolean Type
@@ -27,7 +27,7 @@ Values of type `bool` are truth values, which are either `true` or `false`.
 
 Unsigned integers range from 1 bit to 256 bits.
 [`u8`](https://doc.rust-lang.org/std/primitive.u8.html) to [`u128`](https://doc.rust-lang.org/std/primitive.u128.html) are also supported in Rust.
-`u1`, `u2`, `u4` and `u256` are new to Simfony.
+`u1`, `u2`, `u4` and `u256` are new to SimplicityHL.
 Integer values can be written in decimal notation `123456`, binary notation[^bin] `0b10101010` or hexadecimal notation[^hex] `0xdeadbeef`.
 There are no signed integers.
 
@@ -103,8 +103,8 @@ Arrays are always of finite length.
 | `List<A,`2<sup>N</sup>`>` | <2<sup>N</sup>-list | `list![]`, …, `list![a1, …, a`(2<sup>N</sup> - 1)`]` |
 
 Lists hold a variable number of elements of the same type.
-This is similar to [Rust vectors](https://doc.rust-lang.org/std/vec/struct.Vec.html), but Simfony doesn't have a heap.
-In Simfony, lists exists on the stack, which is why the maximum list length is bounded.
+This is similar to [Rust vectors](https://doc.rust-lang.org/std/vec/struct.Vec.html), but SimplicityHL doesn't have a heap.
+In SimplicityHL, lists exists on the stack, which is why the maximum list length is bounded.
 
 <2-lists hold fewer than 2 elements, so zero or one element.
 <4-lists hold fewer than 4 elements, so zero to three elements.

--- a/book/src/type_alias.md
+++ b/book/src/type_alias.md
@@ -1,6 +1,6 @@
 # Type Aliases
 
-Simfony currently doesn't support Rust-like `struct`s for organizing data.
+SimplicityHL currently doesn't support Rust-like `struct`s for organizing data.
 
 ```rust
 struct User {
@@ -10,7 +10,7 @@ struct User {
 }
 ```
 
-Simfony programmers have to handle long tuples of unlabeled data, which can get messy.
+SimplicityHL programmers have to handle long tuples of unlabeled data, which can get messy.
 
 ```rust
 (bool, u256, u64)

--- a/book/src/type_casting.md
+++ b/book/src/type_casting.md
@@ -1,6 +1,6 @@
 # Casting
 
-A Simfony type can be cast into another Simfony type if both types share the same structure.
+A SimplicityHL type can be cast into another SimplicityHL type if both types share the same structure.
 The structure of a type has to do with how the type is implemented on the Simplicity "processor".
 I will spare you the boring details.
 
@@ -50,7 +50,7 @@ If type `A` can be cast into type `B` and type `B` can be cast into type `C`, th
 
 ## Casting Expression
 
-All casting in Simfony happens explicitly through a casting expression.
+All casting in SimplicityHL happens explicitly through a casting expression.
 
 ```rust
 <Input>::into(input)
@@ -59,7 +59,7 @@ All casting in Simfony happens explicitly through a casting expression.
 The above expression casts the value `input` of type `Input` into some output type.
 The input type of the cast is explict while the output type is implicit.
 
-In Simfony, the output type of every expression is known.
+In SimplicityHL, the output type of every expression is known.
 
 ```rust
 let x: u32 = 1;
@@ -69,7 +69,7 @@ In the above example, the meaning of the expression `1` is clear because of the 
 Here, `1` means a string of 31 zeroes and 1 one.
 _In other contexts, `1` could mean something different, like a string of 255 zeroes and 1 one._
 
-The Simfony compiler knows the type of the outermost expression, and it tries to infer the types of inner expressions based on that.
+The SimplicityHL compiler knows the type of the outermost expression, and it tries to infer the types of inner expressions based on that.
 When it comes to casting expressions, the compiler has no idea about the input type of the cast.
 The programmer needs to supply this information by annotating the cast with its input type.
 

--- a/codegen/Cargo.toml
+++ b/codegen/Cargo.toml
@@ -2,8 +2,8 @@
 name = "codegen"
 version = "0.1.0"
 edition = "2021"
-description = "Generator of Rust code as interface between Simfony and Rust."
+description = "Generator of Rust code as interface between SimplicityHL and Rust."
 publish = false
 
 [dependencies]
-simfony = { path = ".." }
+simplicityhl = { path = ".." }

--- a/codegen/src/jet.rs
+++ b/codegen/src/jet.rs
@@ -1,4 +1,4 @@
-use simfony::simplicity::jet::Elements;
+use simplicityhl::simplicity::jet::Elements;
 use std::fmt;
 
 #[rustfmt::skip]

--- a/codegen/src/main.rs
+++ b/codegen/src/main.rs
@@ -1,12 +1,12 @@
 use std::fs::File;
 use std::io;
 
-use simfony::simplicity::jet::{Elements, Jet};
-use simfony::types::TypeDeconstructible;
+use simplicityhl::simplicity::jet::{Elements, Jet};
+use simplicityhl::types::TypeDeconstructible;
 
 mod jet;
 
-/// Write a Simfony jet as a Rust function to the sink.
+/// Write a SimplicityHL jet as a Rust function to the sink.
 fn write_jet<W: io::Write>(jet: Elements, w: &mut W) -> io::Result<()> {
     for line in jet::documentation(jet).lines() {
         match line.is_empty() {
@@ -19,7 +19,7 @@ fn write_jet<W: io::Write>(jet: Elements, w: &mut W) -> io::Result<()> {
     writeln!(w, "///")?;
     writeln!(w, "/// {} mWU _(milli weight units)_", jet.cost())?;
     write!(w, "pub fn {jet}(")?;
-    let parameters = simfony::jet::source_type(jet);
+    let parameters = simplicityhl::jet::source_type(jet);
     for (i, ty) in parameters.iter().enumerate() {
         let identifier = (b'a' + i as u8) as char;
         if i == parameters.len() - 1 {
@@ -28,10 +28,10 @@ fn write_jet<W: io::Write>(jet: Elements, w: &mut W) -> io::Result<()> {
             write!(w, "{identifier}: {ty}, ")?;
         }
     }
-    let target = simfony::jet::target_type(jet);
+    let target = simplicityhl::jet::target_type(jet);
     match target.is_unit() {
         true => writeln!(w, ") {{")?,
-        false => writeln!(w, ") -> {} {{", simfony::jet::target_type(jet))?,
+        false => writeln!(w, ") -> {} {{", simplicityhl::jet::target_type(jet))?,
     }
 
     writeln!(w, "    todo!()")?;

--- a/doc/context.md
+++ b/doc/context.md
@@ -6,7 +6,7 @@ A context Γ maps variable names to Simplicity types:
 
 We write Γ(`v`) = A to denote that variable `v` has type A in context Γ.
 
-We handle free variables inside Simfony expressions via contexts.
+We handle free variables inside SimplicityHL expressions via contexts.
 
 If all free variables are defined in a context, then the context assigns a type to the expression.
 
@@ -14,7 +14,7 @@ We write Γ ⊩ `a`: A to denote that expression `a` has type A in context Γ.
 
 Note that contexts handle only the **target type** of an expression!
 
-Source types are handled by environments and the translation of Simfony to Simplicity.
+Source types are handled by environments and the translation of SimplicityHL to Simplicity.
 
 We write Γ ⊎ Δ to denote the **disjoint union** of Γ and Δ.
 

--- a/doc/environment.md
+++ b/doc/environment.md
@@ -12,13 +12,13 @@ All expressions inside an environment share the same source type A. We say the e
 ]
 ```
 
-We use environments to translate variables inside Simfony expressions to Simplicity.
+We use environments to translate variables inside SimplicityHL expressions to Simplicity.
 
 The environment tells us the Simplicity expression that returns the value of each variable.
 
-We translate a Simfony program "top to bottom". Each time a variable is defined, we update the environment to reflect this change.
+We translate a SimplicityHL program "top to bottom". Each time a variable is defined, we update the environment to reflect this change.
 
-During the translation, we can ignore the source type of Simplicity expressions (translated Simfony expressions) entirely. We can focus on producing a Simplicity value of the expected target type. Environments ensure that we get input values for each variable that is in scope.
+During the translation, we can ignore the source type of Simplicity expressions (translated SimplicityHL expressions) entirely. We can focus on producing a Simplicity value of the expected target type. Environments ensure that we get input values for each variable that is in scope.
 
 Target types are handled by contexts.
 
@@ -31,7 +31,7 @@ Ctx(Ξ)(`x`) = B if Ξ(`x`) = a: A → B
 
 Patterns occur in let statements `let p := s`.
 
-Pattern `p` binds the output of Simfony expression `s` to variables.
+Pattern `p` binds the output of SimplicityHL expression `s` to variables.
 
 As we translate `s` to Simplicity, we need an environment that maps the variables from `p` to Simplicity expressions.
 

--- a/doc/translation.md
+++ b/doc/translation.md
@@ -1,10 +1,10 @@
 # Translation
 
-We write ⟦`e`⟧Ξ to denote the translation of Simfony expression `e` using environment Ξ from A.
+We write ⟦`e`⟧Ξ to denote the translation of SimplicityHL expression `e` using environment Ξ from A.
 
 The translation produces a Simplicity expression with source type A.
 
-The target type depends on the Simfony expression `e`.
+The target type depends on the SimplicityHL expression `e`.
 
 ## Unit literal
 

--- a/flake.nix
+++ b/flake.nix
@@ -1,5 +1,5 @@
 {
-  description = "Simfony";
+  description = "SimplicityHL";
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.11";

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "simfony-fuzz"
+name = "simplicityhl-fuzz"
 version = "0.0.0"
 publish = false
 edition = "2021"
@@ -10,7 +10,7 @@ cargo-fuzz = true
 [dependencies]
 libfuzzer-sys = "0.4"
 arbitrary = { version = "1", features = ["derive"] }
-simfony = { path = "..", features = ["arbitrary", "serde"]}
+simplicityhl = { path = "..", features = ["arbitrary", "serde"] }
 itertools = "0.13.0"
 serde_json = "1.0.105"
 

--- a/fuzz/fuzz_targets/compile_parse_tree.rs
+++ b/fuzz/fuzz_targets/compile_parse_tree.rs
@@ -3,8 +3,8 @@
 use arbitrary::Arbitrary;
 use libfuzzer_sys::fuzz_target;
 
-use simfony::error::WithFile;
-use simfony::{ast, named, parse, ArbitraryOfType, Arguments};
+use simplicityhl::error::WithFile;
+use simplicityhl::{ast, named, parse, ArbitraryOfType, Arguments};
 
 fuzz_target!(|data: &[u8]| {
     let mut u = arbitrary::Unstructured::new(data);

--- a/fuzz/fuzz_targets/compile_text.rs
+++ b/fuzz/fuzz_targets/compile_text.rs
@@ -3,7 +3,7 @@
 use arbitrary::Arbitrary;
 use libfuzzer_sys::{fuzz_target, Corpus};
 
-use simfony::{ArbitraryOfType, Arguments};
+use simplicityhl::{ArbitraryOfType, Arguments};
 
 /// The PEST parser is slow for inputs with many open brackets.
 /// Detect some of these inputs to reject them from the corpus.
@@ -38,7 +38,7 @@ fuzz_target!(|data: &[u8]| -> Corpus {
     if slow_input(&program_text) {
         return Corpus::Reject;
     }
-    let template = match simfony::TemplateProgram::new(program_text) {
+    let template = match simplicityhl::TemplateProgram::new(program_text) {
         Ok(x) => x,
         Err(..) => return Corpus::Keep,
     };

--- a/fuzz/fuzz_targets/display_parse_tree.rs
+++ b/fuzz/fuzz_targets/display_parse_tree.rs
@@ -2,7 +2,7 @@
 
 use libfuzzer_sys::fuzz_target;
 
-use simfony::parse::{self, ParseFromStr};
+use simplicityhl::parse::{self, ParseFromStr};
 
 fuzz_target!(|parse_program: parse::Program| {
     let program_text = parse_program.to_string();

--- a/fuzz/fuzz_targets/parse_value_rtt.rs
+++ b/fuzz/fuzz_targets/parse_value_rtt.rs
@@ -2,7 +2,7 @@
 
 use libfuzzer_sys::fuzz_target;
 
-use simfony::value::Value;
+use simplicityhl::value::Value;
 
 fuzz_target!(|value: Value| {
     let value_string = value.to_string();

--- a/fuzz/fuzz_targets/parse_witness_json_rtt.rs
+++ b/fuzz/fuzz_targets/parse_witness_json_rtt.rs
@@ -2,7 +2,7 @@
 
 use libfuzzer_sys::fuzz_target;
 
-use simfony::WitnessValues;
+use simplicityhl::WitnessValues;
 
 fuzz_target!(|witness_values: WitnessValues| {
     let witness_text = serde_json::to_string(&witness_values)

--- a/fuzz/fuzz_targets/parse_witness_module_rtt.rs
+++ b/fuzz/fuzz_targets/parse_witness_module_rtt.rs
@@ -2,8 +2,8 @@
 
 use libfuzzer_sys::fuzz_target;
 
-use simfony::parse::ParseFromStr;
-use simfony::WitnessValues;
+use simplicityhl::parse::ParseFromStr;
+use simplicityhl::WitnessValues;
 
 fuzz_target!(|witness_values: WitnessValues| {
     let witness_text = witness_values.to_string();

--- a/fuzz/fuzz_targets/reconstruct_value.rs
+++ b/fuzz/fuzz_targets/reconstruct_value.rs
@@ -2,7 +2,7 @@
 
 use libfuzzer_sys::fuzz_target;
 
-use simfony::value::{StructuralValue, Value};
+use simplicityhl::value::{StructuralValue, Value};
 
 fuzz_target!(|value: Value| {
     let structural_value = StructuralValue::from(&value);

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -830,7 +830,7 @@ impl Expression {
     /// ## Const evaluation
     ///
     /// The returned expression might not be evaluable at compile time.
-    /// The details depend on the current state of the Simfony compiler.
+    /// The details depend on the current state of the SimplicityHL compiler.
     pub fn analyze_const(from: &parse::Expression, ty: &ResolvedType) -> Result<Self, RichError> {
         let mut empty_scope = Scope::default();
         Self::analyze(from, ty, &mut empty_scope)

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -23,11 +23,11 @@ use crate::value::StructuralValue;
 use crate::witness::Arguments;
 use crate::{ProgNode, Value};
 
-/// Each Simfony expression expects an _input value_.
-/// A Simfony expression is translated into a Simplicity expression
+/// Each SimplicityHL expression expects an _input value_.
+/// A SimplicityHL expression is translated into a Simplicity expression
 /// that similarly expects an _input value_.
 ///
-/// Simfony variable names are translated into Simplicity expressions
+/// SimplicityHL variable names are translated into Simplicity expressions
 /// that extract the seeked value from the _input value_.
 ///
 /// Each (nested) block expression introduces a new scope.
@@ -64,7 +64,7 @@ struct Scope {
     ctx: simplicity::types::Context,
     /// Tracker of function calls.
     call_tracker: Arc<CallTracker>,
-    /// Values for parameters inside the Simfony program.
+    /// Values for parameters inside the SimplicityHL program.
     arguments: Arguments,
     include_debug_symbols: bool,
 }
@@ -247,7 +247,7 @@ fn compile_blk(
 }
 
 impl Program {
-    /// Compile the Simfony source code to Simplicity target code.
+    /// Compile the SimplicityHL source code to Simplicity target code.
     ///
     /// ## Precondition
     ///
@@ -402,9 +402,9 @@ impl Call {
             }
             CallName::TypeCast(..) => {
                 // A cast converts between two structurally equal types.
-                // Structural equality of Simfony types A and B means
+                // Structural equality of SimplicityHL types A and B means
                 // exact equality of the underlying Simplicity types of A and of B.
-                // Therefore, a Simfony cast is a NOP in Simplicity.
+                // Therefore, a SimplicityHL cast is a NOP in Simplicity.
                 Ok(args)
             }
             CallName::Custom(function) => {

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -9,13 +9,13 @@ use crate::error::Span;
 use crate::types::ResolvedType;
 use crate::value::{StructuralValue, Value};
 
-/// Tracker of Simfony call expressions inside Simplicity target code.
+/// Tracker of SimplicityHL call expressions inside Simplicity target code.
 ///
 /// Tracking happens via CMRs that are inserted into the Simplicity target code.
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct DebugSymbols(HashMap<Cmr, TrackedCall>);
 
-/// Intermediate representation of tracked Simfony call expressions
+/// Intermediate representation of tracked SimplicityHL call expressions
 /// that is mutable and that lacks information about the source file.
 ///
 /// The struct can be converted to [`DebugSymbols`] by providing the source file.
@@ -71,7 +71,7 @@ pub struct DebugValue {
 
 impl DebugSymbols {
     /// Insert a tracked call expression.
-    /// Use the Simfony source `file` to extract the Simfony text of the expression.
+    /// Use the SimplicityHL source `file` to extract the SimplicityHL text of the expression.
     pub(crate) fn insert(&mut self, span: Span, cmr: Cmr, name: TrackedCallName, file: &str) {
         let text = remove_excess_whitespace(span.to_slice(file).unwrap_or(""));
         let text = text
@@ -152,7 +152,7 @@ impl CallTracker {
 }
 
 impl TrackedCall {
-    /// Access the text of the Simfony call expression.
+    /// Access the text of the SimplicityHL call expression.
     pub fn text(&self) -> &str {
         &self.text
     }
@@ -197,7 +197,7 @@ impl TrackedCall {
 }
 
 impl FallibleCall {
-    /// Access the Simfony text of the call expression.
+    /// Access the SimplicityHL text of the call expression.
     pub fn text(&self) -> &str {
         &self.text
     }
@@ -209,7 +209,7 @@ impl FallibleCall {
 }
 
 impl DebugValue {
-    /// Access the Simfony text of the debug expression.
+    /// Access the SimplicityHL text of the debug expression.
     pub fn text(&self) -> &str {
         &self.text
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -301,8 +301,8 @@ pub enum Error {
     CannotParse(String),
     Grammar(String),
     IncompatibleMatchArms(MatchPattern, MatchPattern),
-    // TODO: Remove CompileError once Simfony has a type system
-    // The Simfony compiler should never produce ill-typed Simplicity code
+    // TODO: Remove CompileError once SimplicityHL has a type system
+    // The SimplicityHL compiler should never produce ill-typed Simplicity code
     // The compiler can only be this precise if it knows a type system at least as expressive as Simplicity's
     CannotCompile(String),
     JetDoesNotExist(JetName),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-//! Library for parsing and compiling simfony
+//! Library for parsing and compiling SimplicityHL
 
 pub type ProgNode = Arc<named::ConstructNode>;
 
@@ -36,7 +36,7 @@ pub use crate::types::ResolvedType;
 pub use crate::value::Value;
 pub use crate::witness::{Arguments, Parameters, WitnessTypes, WitnessValues};
 
-/// The template of a Simfony program.
+/// The template of a SimplicityHL program.
 ///
 /// A template has parameterized values that need to be supplied with arguments.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -46,11 +46,11 @@ pub struct TemplateProgram {
 }
 
 impl TemplateProgram {
-    /// Parse the template of a Simfony program.
+    /// Parse the template of a SimplicityHL program.
     ///
     /// ## Errors
     ///
-    /// The string is not a valid Simfony program.
+    /// The string is not a valid SimplicityHL program.
     pub fn new<Str: Into<Arc<str>>>(s: Str) -> Result<Self, String> {
         let file = s.into();
         let parse_program = parse::Program::parse_from_str(&file)?;
@@ -91,7 +91,7 @@ impl TemplateProgram {
     }
 }
 
-/// A Simfony program, compiled to Simplicity.
+/// A SimplicityHL program, compiled to Simplicity.
 #[derive(Clone, Debug)]
 pub struct CompiledProgram {
     simplicity: ProgNode,
@@ -111,7 +111,7 @@ impl Default for CompiledProgram {
 }
 
 impl CompiledProgram {
-    /// Parse and compile a Simfony program from the given string.
+    /// Parse and compile a SimplicityHL program from the given string.
     ///
     /// ## See
     ///
@@ -133,25 +133,25 @@ impl CompiledProgram {
 
     /// Access the Simplicity target code, without witness data.
     pub fn commit(&self) -> Arc<CommitNode<Elements>> {
-        named::to_commit_node(&self.simplicity).expect("Compiled Simfony program has type 1 -> 1")
+        named::to_commit_node(&self.simplicity).expect("Compiled SimplicityHL program has type 1 -> 1")
     }
 
-    /// Satisfy the Simfony program with the given `witness_values`.
+    /// Satisfy the SimplicityHL program with the given `witness_values`.
     ///
     /// ## Errors
     ///
-    /// - Witness values have a different type than declared in the Simfony program.
+    /// - Witness values have a different type than declared in the SimplicityHL program.
     /// - There are missing witness values.
     pub fn satisfy(&self, witness_values: WitnessValues) -> Result<SatisfiedProgram, String> {
         self.satisfy_with_env(witness_values, None)
     }
 
-    /// Satisfy the Simfony program with the given `witness_values`.
+    /// Satisfy the SimplicityHL program with the given `witness_values`.
     /// If `env` is `None`, the program is not pruned, otherwise it is pruned with the given environment.
     ///
     /// ## Errors
     ///
-    /// - Witness values have a different type than declared in the Simfony program.
+    /// - Witness values have a different type than declared in the SimplicityHL program.
     /// - There are missing witness values.
     pub fn satisfy_with_env(
         &self,
@@ -173,7 +173,7 @@ impl CompiledProgram {
     }
 }
 
-/// A Simfony program, compiled to Simplicity and satisfied with witness data.
+/// A SimplicityHL program, compiled to Simplicity and satisfied with witness data.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct SatisfiedProgram {
     simplicity: Arc<RedeemNode<Elements>>,
@@ -181,7 +181,7 @@ pub struct SatisfiedProgram {
 }
 
 impl SatisfiedProgram {
-    /// Parse, compile and satisfy a Simfony program from the given string.
+    /// Parse, compile and satisfy a SimplicityHL program from the given string.
     ///
     /// ## See
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,7 +133,8 @@ impl CompiledProgram {
 
     /// Access the Simplicity target code, without witness data.
     pub fn commit(&self) -> Arc<CommitNode<Elements>> {
-        named::to_commit_node(&self.simplicity).expect("Compiled SimplicityHL program has type 1 -> 1")
+        named::to_commit_node(&self.simplicity)
+            .expect("Compiled SimplicityHL program has type 1 -> 1")
     }
 
     /// Satisfy the SimplicityHL program with the given `witness_values`.

--- a/src/main.rs
+++ b/src/main.rs
@@ -68,7 +68,8 @@ fn run() -> Result<(), String> {
             .map(|wit_file| -> Result<simplicityhl::WitnessValues, String> {
                 let wit_path = std::path::Path::new(wit_file);
                 let wit_text = std::fs::read_to_string(wit_path).map_err(|e| e.to_string())?;
-                let witness = serde_json::from_str::<simplicityhl::WitnessValues>(&wit_text).unwrap();
+                let witness =
+                    serde_json::from_str::<simplicityhl::WitnessValues>(&wit_text).unwrap();
                 Ok(witness)
             })
             .transpose()?

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,7 @@ use base64::display::Base64Display;
 use base64::engine::general_purpose::STANDARD;
 use clap::{Arg, ArgAction, Command};
 
-use simfony::{Arguments, CompiledProgram};
+use simplicityhl::{Arguments, CompiledProgram};
 use std::env;
 
 // Directly returning Result<(), String> prints the error using Debug
@@ -19,8 +19,8 @@ fn run() -> Result<(), String> {
         Command::new(env!("CARGO_BIN_NAME"))
             .about(
                 "\
-                Compile the given Simfony program and print the resulting Simplicity base64 string.\n\
-                If a Simfony witness is provided, then use it to satisfy the program (requires \
+                Compile the given SimplicityHL program and print the resulting Simplicity base64 string.\n\
+                If a SimplicityHL witness is provided, then use it to satisfy the program (requires \
                 feature 'serde' to be enabled).\
                 ",
             )
@@ -29,7 +29,7 @@ fn run() -> Result<(), String> {
                     .required(true)
                     .value_name("PROGRAM_FILE")
                     .action(ArgAction::Set)
-                    .help("Simfony program file to build"),
+                    .help("SimplicityHL program file to build"),
             )
     };
 
@@ -65,16 +65,16 @@ fn run() -> Result<(), String> {
     let witness_opt = {
         matches
             .get_one::<String>("wit_file")
-            .map(|wit_file| -> Result<simfony::WitnessValues, String> {
+            .map(|wit_file| -> Result<simplicityhl::WitnessValues, String> {
                 let wit_path = std::path::Path::new(wit_file);
                 let wit_text = std::fs::read_to_string(wit_path).map_err(|e| e.to_string())?;
-                let witness = serde_json::from_str::<simfony::WitnessValues>(&wit_text).unwrap();
+                let witness = serde_json::from_str::<simplicityhl::WitnessValues>(&wit_text).unwrap();
                 Ok(witness)
             })
             .transpose()?
     };
     #[cfg(not(feature = "serde"))]
-    let witness_opt: Option<simfony::WitnessValues> = None;
+    let witness_opt: Option<simplicityhl::WitnessValues> = None;
 
     if let Some(witness) = witness_opt {
         let satisfied = compiled.satisfy(witness)?;

--- a/src/named.rs
+++ b/src/named.rs
@@ -98,7 +98,7 @@ pub fn to_commit_node(node: &ConstructNode) -> Result<Arc<CommitNode<Elements>>,
 ///
 /// It is the responsibility of the caller to ensure that the given witness `values` match the
 /// types in the construct `node`. This can be done by calling [`WitnessValues::is_consistent`]
-/// on the original Simfony program before it is compiled to Simplicity.
+/// on the original SimplicityHL program before it is compiled to Simplicity.
 pub fn to_witness_node(node: &ConstructNode, values: WitnessValues) -> Arc<WitnessNode<Elements>> {
     struct Populator {
         values: WitnessValues,

--- a/src/pattern.rs
+++ b/src/pattern.rs
@@ -157,7 +157,7 @@ impl crate::ArbitraryRec for Pattern {
     }
 }
 
-/// Basic structure of a Simfony value for pattern matching.
+/// Basic structure of a SimplicityHL value for pattern matching.
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub enum BasePattern {
     /// Ignore: Match any value.

--- a/src/types.rs
+++ b/src/types.rs
@@ -9,7 +9,7 @@ use crate::array::{BTreeSlice, Partition};
 use crate::num::{NonZeroPow2Usize, Pow2Usize};
 use crate::str::AliasName;
 
-/// Primitives of the Simfony type system, excluding type aliases.
+/// Primitives of the SimplicityHL type system, excluding type aliases.
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
 #[non_exhaustive]
 pub enum TypeInner<A> {
@@ -315,7 +315,7 @@ pub trait TypeDeconstructible: Sized {
     fn as_list(&self) -> Option<(&Self, NonZeroPow2Usize)>;
 }
 
-/// Simfony type without type aliases.
+/// SimplicityHL type without type aliases.
 #[derive(PartialEq, Eq, Hash, Clone)]
 pub struct ResolvedType(TypeInner<Arc<Self>>);
 
@@ -484,7 +484,7 @@ impl<'a> arbitrary::Arbitrary<'a> for ResolvedType {
     }
 }
 
-/// Simfony type with type aliases.
+/// SimplicityHL type with type aliases.
 #[derive(PartialEq, Eq, Hash, Clone)]
 pub struct AliasedType(AliasedInner);
 
@@ -911,7 +911,7 @@ impl FromStr for BuiltinAlias {
     }
 }
 
-/// Internal structure of a Simfony type.
+/// Internal structure of a SimplicityHL type.
 /// 1:1 isomorphism to Simplicity.
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct StructuralType(Arc<Final>);

--- a/src/value.rs
+++ b/src/value.rs
@@ -528,7 +528,10 @@ impl ValueConstructible for Value {
     }
 
     fn none(inner: Self::Type) -> Self {
-        Self { inner: ValueInner::Option(None), ty: ResolvedType::option(inner) }
+        Self {
+            inner: ValueInner::Option(None),
+            ty: ResolvedType::option(inner),
+        }
     }
 
     fn some(inner: Self) -> Self {
@@ -541,15 +544,24 @@ impl ValueConstructible for Value {
     fn tuple<I: IntoIterator<Item = Self>>(elements: I) -> Self {
         let values: Arc<[Self]> = elements.into_iter().collect();
         let ty = ResolvedType::tuple(values.iter().map(Value::ty).map(ResolvedType::clone));
-        Self { inner: ValueInner::Tuple(values), ty }
+        Self {
+            inner: ValueInner::Tuple(values),
+            ty,
+        }
     }
 
     fn array<I: IntoIterator<Item = Self>>(elements: I, ty: Self::Type) -> Self {
         let values: Arc<[Self]> = elements.into_iter().collect();
         for value in values.iter() {
-            assert!(value.is_of_type(&ty), "Element {value} is not of expected type {ty}");
+            assert!(
+                value.is_of_type(&ty),
+                "Element {value} is not of expected type {ty}"
+            );
         }
-        Self { ty: ResolvedType::array(ty, values.len()), inner: ValueInner::Array(values) }
+        Self {
+            ty: ResolvedType::array(ty, values.len()),
+            inner: ValueInner::Array(values),
+        }
     }
 
     fn list<I: IntoIterator<Item = Self>>(
@@ -563,21 +575,33 @@ impl ValueConstructible for Value {
             "There must be fewer list elements than the bound {bound}"
         );
         for element in elements.iter() {
-            assert!(element.is_of_type(&ty), "Element {element} is not of expected type {ty}");
+            assert!(
+                element.is_of_type(&ty),
+                "Element {element} is not of expected type {ty}"
+            );
         }
-        Self { inner: ValueInner::List(elements, bound), ty: ResolvedType::list(ty, bound) }
+        Self {
+            inner: ValueInner::List(elements, bound),
+            ty: ResolvedType::list(ty, bound),
+        }
     }
 }
 
 impl From<bool> for Value {
     fn from(value: bool) -> Self {
-        Self { inner: ValueInner::Boolean(value), ty: ResolvedType::boolean() }
+        Self {
+            inner: ValueInner::Boolean(value),
+            ty: ResolvedType::boolean(),
+        }
     }
 }
 
 impl From<UIntValue> for Value {
     fn from(value: UIntValue) -> Self {
-        Self { ty: value.get_type().into(), inner: ValueInner::UInt(value) }
+        Self {
+            ty: value.get_type().into(),
+            inner: ValueInner::UInt(value),
+        }
     }
 }
 
@@ -911,7 +935,10 @@ impl ValueConstructible for StructuralValue {
     fn array<I: IntoIterator<Item = Self>>(elements: I, ty: Self::Type) -> Self {
         let elements: Vec<Self> = elements.into_iter().collect();
         for element in &elements {
-            assert!(element.is_of_type(&ty), "Element {element} is not of expected type {ty}");
+            assert!(
+                element.is_of_type(&ty),
+                "Element {element} is not of expected type {ty}"
+            );
         }
         let tree = BTreeSlice::from_slice(&elements);
         tree.fold(Self::product).unwrap_or_else(Self::unit)
@@ -928,7 +955,10 @@ impl ValueConstructible for StructuralValue {
             "There must be fewer list elements than the bound {bound}"
         );
         for element in &elements {
-            assert!(element.is_of_type(&ty), "Element {element} is not of expected type {ty}");
+            assert!(
+                element.is_of_type(&ty),
+                "Element {element} is not of expected type {ty}"
+            );
         }
         let partition = Partition::from_slice(&elements, bound);
         let process = |block: &[Self], size: usize| -> Self {
@@ -1028,7 +1058,10 @@ impl StructuralValue {
     }
 
     fn destruct<'a>(&'a self, ty: &'a ResolvedType) -> Destructor<'a> {
-        Destructor::Ok { value: self.0.as_ref(), ty }
+        Destructor::Ok {
+            value: self.0.as_ref(),
+            ty,
+        }
     }
 }
 
@@ -1060,7 +1093,10 @@ impl StructuralValue {
 /// from the leaf Simplicity values may fail, in which case the entire tree is, again, ill-typed.
 #[derive(Clone, Debug)]
 enum Destructor<'a> {
-    Ok { value: ValueRef<'a>, ty: &'a ResolvedType },
+    Ok {
+        value: ValueRef<'a>,
+        ty: &'a ResolvedType,
+    },
     WrongType,
 }
 
@@ -1211,8 +1247,10 @@ mod tests {
         assert_eq!("(1, 42, 1337)", &triple.to_string());
         let empty_array = Value::array([], ResolvedType::unit());
         assert_eq!("[]", &empty_array.to_string());
-        let array =
-            Value::array([Value::unit(), Value::unit(), Value::unit()], ResolvedType::unit());
+        let array = Value::array(
+            [Value::unit(), Value::unit(), Value::unit()],
+            ResolvedType::unit(),
+        );
         assert_eq!("[(), (), ()]", &array.to_string());
         let list = Value::list([Value::unit()], ResolvedType::unit(), NonZeroPow2Usize::TWO);
         assert_eq!("list![()]", &list.to_string());
@@ -1261,7 +1299,10 @@ mod tests {
             (
                 "[1, 2, 3]",
                 ResolvedType::array(UIntType::U4.into(), 3),
-                Value::array([Value::u4(1), Value::u4(2), Value::u4(3)], UIntType::U4.into()),
+                Value::array(
+                    [Value::u4(1), Value::u4(2), Value::u4(3)],
+                    UIntType::U4.into(),
+                ),
             ),
             (
                 "list![1, 2, 3]",

--- a/vscode/LICENSE
+++ b/vscode/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Simfony contributors
+Copyright (c) 2025 SimplicityHL contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/vscode/README.md
+++ b/vscode/README.md
@@ -1,4 +1,4 @@
-# SimplicityHL (Simfony) extension for VSCode
+# SimplicityHL extension for VSCode
 
 VSCode extension that provides syntax highlighting for the [SimplicityHL](https://github.com/BlockstreamResearch/SimplicityHL) programming language.
 

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -1,8 +1,8 @@
 {
   "name": "simplicityhl",
-  "displayName": "SimplicityHL (Simfony) Language Support",
+  "displayName": "SimplicityHL Language Support",
   "description": "Syntax highlighting and autocompletion for SimplicityHL (Simfony) language",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "publisher": "Simplicity",
   "repository": {
     "type": "git",


### PR DESCRIPTION
AFAIK the only remaining reference is to  https://github.com/uncomputable/simfony-as-rust (generates: https://docs.rs/simfony-as-rust/) in the file `SimplicityHL/book/src/function.md`. I would presume that this should be updated too.