### PR TITLE
Update rust-simplicity dep and prepare for initial release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
-# 0.1.0 - 2025-04-10
+# 0.2.0 - 2025-07-29
 
+* Renamed from [Simfony](https://crates.io/crates/simfony)
 * Initial release. Not recommended for production use.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -110,7 +110,7 @@ dependencies = [
  "bitcoin-io",
  "bitcoin-units",
  "bitcoin_hashes",
- "hex-conservative 0.2.1",
+ "hex-conservative",
  "hex_lit",
  "secp256k1",
 ]
@@ -149,7 +149,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb18c03d0db0247e147a21a6faafd5a7eb851c743db062de72018b6b7e8e4d16"
 dependencies = [
  "bitcoin-io",
- "hex-conservative 0.2.1",
+ "hex-conservative",
 ]
 
 [[package]]
@@ -307,12 +307,6 @@ dependencies = [
  "wasi",
  "wasm-bindgen",
 ]
-
-[[package]]
-name = "hex-conservative"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30ed443af458ccb6d81c1e7e661545f94d3176752fb1df2f543b902a1e0f51e2"
 
 [[package]]
 name = "hex-conservative"
@@ -622,16 +616,16 @@ dependencies = [
 
 [[package]]
 name = "simplicity-lang"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "219a9eccc5f9841f0fea0bf57ce4ed7403405fd189bd39a212d13f1f19748570"
+checksum = "525879699aba1f7f75c0d97355475072adeb0ed0530df4e18f23235252475e68"
 dependencies = [
  "bitcoin",
  "bitcoin_hashes",
  "byteorder",
  "elements",
  "getrandom",
- "hex-conservative 0.1.1",
+ "hex-conservative",
  "miniscript",
  "santiago",
  "simplicity-sys",
@@ -639,9 +633,9 @@ dependencies = [
 
 [[package]]
 name = "simplicity-sys"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9c453a3edfff1ca89b03616a0028f5dc0da0ac5099665ee63357561edf1db71"
+checksum = "3abf9c7d64c5bf45bb2fb966f3b0637d8c13c8d5cdfbd7587900421cb7584c49"
 dependencies = [
  "bitcoin_hashes",
  "cc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -643,7 +643,7 @@ dependencies = [
 
 [[package]]
 name = "simplicityhl"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "arbitrary",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ pest = "2.1.3"
 pest_derive = "2.7.1"
 serde = { version = "1.0.188", features = ["derive"], optional = true }
 serde_json = { version = "1.0.105", optional = true }
-simplicity-lang = { version = "0.4.0" }
+simplicity-lang = { version = "0.5.0" }
 miniscript = "12.3.1"
 either = "1.12.0"
 itertools = "0.13.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "simplicityhl"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["sanket1729 <sanket1729@gmail.com>"]
 license = "CC0-1.0"
 homepage = "https://github.com/BlockstreamResearch/SimplicityHL"

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,3 +1,5 @@
 msrv = "1.78.0"
 # We have an error type, `RichError`, of size 144. This is pushing it but probably fine.
 large-error-threshold = 145
+
+doc-valid-idents = [ "SimplicityHL" ]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -405,7 +405,7 @@ mod tests {
     impl TestCase<SatisfiedProgram> {
         #[allow(dead_code)]
         pub fn print_encoding(self) -> Self {
-            let (program_bytes, witness_bytes) = self.program.redeem().encode_to_vec();
+            let (program_bytes, witness_bytes) = self.program.redeem().to_vec_with_witness();
             println!(
                 "Program:\n{}",
                 Base64Display::new(&program_bytes, &STANDARD)

--- a/src/main.rs
+++ b/src/main.rs
@@ -79,7 +79,7 @@ fn run() -> Result<(), String> {
 
     if let Some(witness) = witness_opt {
         let satisfied = compiled.satisfy(witness)?;
-        let (program_bytes, witness_bytes) = satisfied.redeem().encode_to_vec();
+        let (program_bytes, witness_bytes) = satisfied.redeem().to_vec_with_witness();
         println!(
             "Program:\n{}",
             Base64Display::new(&program_bytes, &STANDARD)
@@ -89,7 +89,7 @@ fn run() -> Result<(), String> {
             Base64Display::new(&witness_bytes, &STANDARD)
         );
     } else {
-        let program_bytes = compiled.commit().encode_to_vec();
+        let program_bytes = compiled.commit().to_vec_without_witness();
         println!(
             "Program:\n{}",
             Base64Display::new(&program_bytes, &STANDARD)


### PR DESCRIPTION
No major changes (well, many changes since simfony 0.1 in April); but we are ready to release under the new name.