### PR TITLE
remove orphan heading "Locking and unlocking UTXOs"

### DIFF
--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -12,5 +12,3 @@
 - [Match Expression](./match_expression.md)
 - [Functions](./function.md)
 - [Programs](./program.md)
-
-# Locking and Unlocking UTXOs


### PR DESCRIPTION
While I'd love to know what was going to be added here, it's better that we remove the headline until we have content for it. 