### PR TITLE
feat: add padding keyword to increase program size

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -303,6 +303,8 @@ pub enum CallName {
     Panic,
     /// [`dbg!`].
     Debug,
+    /// Padding that inflates the program without changing what it computes.
+    Padding(NonZeroUsize),
     /// Cast from the given source type.
     TypeCast(ResolvedType),
     /// A custom function that was defined previously.
@@ -332,6 +334,7 @@ impl PartialEq for CallName {
             (Self::Assert, Self::Assert) => true,
             (Self::Panic, Self::Panic) => true,
             (Self::Debug, Self::Debug) => true,
+            (Self::Padding(a), Self::Padding(b)) => a == b,
             (Self::TypeCast(a), Self::TypeCast(b)) => a == b,
             (Self::Custom(a), Self::Custom(b)) => a == b,
             (Self::Fold(a, b), Self::Fold(c, d)) => a == c && b == d,
@@ -2175,6 +2178,12 @@ impl AbstractSyntaxTree for Call {
                 scope.track_call(from, TrackedCallName::Debug(arg_ty));
                 args
             }
+            CallName::Padding(_) => {
+                let args_tys = [];
+                check_argument_types(from.args(), &args_tys).with_span(from)?;
+                check_output_type(&ResolvedType::unit(), ty).with_span(from)?;
+                analyze_arguments(from.args(), &args_tys, scope)?
+            }
             CallName::TypeCast(source) => {
                 // Casts prove structural equality, but enums are nominal:
                 // every enum must map to itself at its structural position
@@ -2310,6 +2319,19 @@ impl AbstractSyntaxTree for CallName {
             parse::CallName::Assert => Ok(Self::Assert),
             parse::CallName::Panic => Ok(Self::Panic),
             parse::CallName::Debug => Ok(Self::Debug),
+            parse::CallName::Padding(size) => {
+                // The text parser rejects oversized padding, but a `parse::Program`
+                // can also be built directly (fuzzing), so re-check it here.
+                if size.get() > parse::MAX_PADDING_SIZE {
+                    Err(Error::PaddingSizeTooLarge {
+                        size: size.get(),
+                        max: parse::MAX_PADDING_SIZE,
+                    })
+                    .with_span(from)
+                } else {
+                    Ok(Self::Padding(*size))
+                }
+            }
             parse::CallName::TypeCast(target) => {
                 scope.resolve(target).map(Self::TypeCast).with_span(from)
             }
@@ -3644,5 +3666,93 @@ mod literal_tests {
             assert_eq!(value, &expected, "unexpected value for {source:?}");
             assert_eq!(single.span().to_slice(source), Some(source));
         }
+    }
+}
+
+#[cfg(test)]
+mod padding_tests {
+    use crate::{error, parse::ParseFromStr};
+
+    use super::*;
+
+    /// Parse `input` and return the single `padding::<N>()` call it consists of.
+    fn parse_padding(input: &str) -> parse::Call {
+        let parsed = parse::Expression::parse_from_str(input).expect("Failed to parse");
+
+        match parsed.inner() {
+            parse::ExpressionInner::Single(single) => match single.inner() {
+                parse::SingleExpressionInner::Call(call) => match call.name() {
+                    parse::CallName::Padding(_) => call.clone(),
+                    name => panic!("Expected a padding call, found `{name}`"),
+                },
+                _ => panic!("Expected a call expression"),
+            },
+            _ => panic!("Expected a single expression"),
+        }
+    }
+
+    #[test]
+    fn test_ast_padding() {
+        let input = "padding::<10>()";
+
+        let parsed_call = &parse_padding(input);
+
+        let mut scope = Scope::default();
+        let ast_padding = Call::analyze(parsed_call, &ResolvedType::unit(), &mut scope)
+            .expect("Failed to analyze Padding expression");
+
+        assert_eq!(
+            ast_padding.args().len(),
+            0,
+            "Args did not analyse correctly"
+        );
+        assert_eq!(
+            ast_padding.name(),
+            &CallName::Padding(NonZeroUsize::new(10).unwrap()),
+            "Call name was not padding"
+        );
+    }
+
+    #[test]
+    fn test_ast_padding_rejects_size_above_max() {
+        // The text parser caps the size, but a parse tree can be built directly
+        // (as the fuzz targets do), so analysis has to reject it too.
+        let oversized = parse::CallName::Padding(
+            NonZeroUsize::new(parse::MAX_PADDING_SIZE + 1).expect("non-zero"),
+        );
+        let call = parse::Call::new_unparsed(oversized, Arc::from([]), Span::new(0, 0..0));
+
+        let mut scope = Scope::default();
+        let res = Call::analyze(&call, &ResolvedType::unit(), &mut scope);
+
+        assert!(
+            matches!(
+                res.unwrap_err().error(),
+                error::Error::PaddingSizeTooLarge { size, max }
+                    if *size == parse::MAX_PADDING_SIZE + 1 && *max == parse::MAX_PADDING_SIZE
+            ),
+            "oversized padding was accepted but should have been rejected"
+        );
+    }
+
+    #[test]
+    fn test_ast_padding_should_fail_with_args() {
+        let input = "padding::<10>(1)";
+
+        let parsed_call = &parse_padding(input);
+
+        let mut scope = Scope::default();
+        let res = Call::analyze(parsed_call, &ResolvedType::unit(), &mut scope);
+
+        assert!(
+            matches!(
+                res.unwrap_err().error(),
+                error::Error::InvalidNumberOfArguments {
+                    expected: 0,
+                    found: 1
+                }
+            ),
+            "padding parsed correctly but should have failed"
+        );
     }
 }

--- a/src/compile/mod.rs
+++ b/src/compile/mod.rs
@@ -448,6 +448,16 @@ impl Call {
                 let iden = ProgNode::iden(scope.ctx());
                 scope.with_debug_symbol(args, &iden, self)
             }
+            CallName::Padding(size) => {
+                // Each layer composes one more `unit` onto the chain. Used for increasing
+                // the size of the program to increase the budget.
+                let unit = ProgNode::unit(scope.ctx());
+                let mut padded = PairBuilder::unit(scope.ctx());
+                for _ in 0..size.get() {
+                    padded = padded.comp(&unit).with_span(self)?;
+                }
+                Ok(padded)
+            }
             CallName::TypeCast(..) => {
                 // A cast converts between two structurally equal types.
                 // Structural equality of SimplicityHL types A and B means
@@ -757,5 +767,79 @@ impl EnumMatch {
         let scrutinee = self.scrutinee().compile(scope)?;
         let input = scrutinee.pair(PairBuilder::iden(scope.ctx()));
         input.comp(&dispatch).with_span(self)
+    }
+}
+
+#[cfg(test)]
+mod padding_tests {
+    use crate::{
+        ast::{self, ElementsJetHinter},
+        parse::{self, ParseFromStr},
+    };
+
+    use super::*;
+
+    fn compile_program(input: &str) -> Result<Arc<named::CommitNode>, Diagnostic> {
+        let parse_program = parse::Program::parse_from_str(input).expect("Failed to parse");
+        let ast_program = ast::Program::analyze(&parse_program, Box::new(ElementsJetHinter))
+            .expect("Failed to analyze");
+        ast_program.compile(Arguments::default(), false, Box::new(ElementsJetHinter))
+    }
+
+    /// Compile `fn main() { padding::<size>(); }` and return the encoded program length.
+    fn encoded_len(size: usize) -> usize {
+        let program = compile_program(&format!("fn main() {{ padding::<{size}>(); }}"))
+            .expect("padding expression should compile");
+        named::forget_names(&program).to_vec_without_witness().len()
+    }
+
+    #[test]
+    fn test_padding_compiles() {
+        let input_program = r#"
+        fn main() {
+            padding::<20>();
+        }"#;
+
+        compile_program(input_program).expect("padding expression should compile");
+    }
+
+    /// Count the nodes of the compiled program under the same maximal sharing
+    /// that the encoder applies.
+    fn shared_node_count(size: usize) -> usize {
+        let program = compile_program(&format!("fn main() {{ padding::<{size}>(); }}"))
+            .expect("padding expression should compile");
+        let program = named::forget_names(&program);
+        simplicity::dag::DagLike::post_order_iter::<
+            simplicity::dag::MaxSharing<simplicity::node::Commit>,
+        >(&*program)
+        .count()
+    }
+
+    #[test]
+    fn test_padding_layers_are_not_shared() {
+        // Each layer's `comp` has a distinct left child (the chain built so far), so it
+        // has a distinct CMR. Maximal sharing -- what the encoder applies -- therefore
+        // cannot collapse the chain. If it could, padding would be a no-op.
+        let base = shared_node_count(10);
+        let extra = shared_node_count(110);
+
+        assert_eq!(
+            extra - base,
+            100,
+            "expected one fresh node per padding layer, got {} across 100 extra layers",
+            extra - base
+        );
+    }
+
+    #[test]
+    fn test_padding_grows_the_program() {
+        // The whole point of padding is to make the program bigger.
+        let small = encoded_len(1);
+        let large = encoded_len(20);
+
+        assert!(
+            large > small,
+            "padding::<20> encoded to {large} bytes, no larger than padding::<1> at {small}"
+        );
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -895,6 +895,11 @@ pub enum Error {
         declared: ResolvedType,
         assigned: ResolvedType,
     },
+    PaddingSizeZero,
+    PaddingSizeTooLarge {
+        size: usize,
+        max: usize,
+    },
 }
 
 #[rustfmt::skip]
@@ -1155,6 +1160,11 @@ impl fmt::Display for Error {
             Error::ArgumentTypeMismatch { name, declared, assigned } => write!(
                 f,
                 "Parameter `{name}` was declared with type `{declared}` but its assigned argument is of type `{assigned}`"
+            ),
+            Error::PaddingSizeZero => write!(f, "Padding size cannot be zero"),
+            Error::PaddingSizeTooLarge { size, max } => write!(
+                f,
+                "Expected a padding size of at most {max}, found {size}"
             ),
         }
     }

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -537,6 +537,80 @@ pub fn is_keyword(s: &str) -> bool {
 mod original_lexer {
     use super::*;
 
+    /// Helper function to get the variant name of a token
+    fn variant_name(token: &Token) -> &'static str {
+        match token {
+            Token::Pub => "Pub",
+            Token::Use => "Use",
+            Token::As => "As",
+            Token::Fn => "Fn",
+            Token::Let => "Let",
+            Token::Type => "Type",
+            Token::Mod => "Mod",
+            Token::Const => "Const",
+            Token::Match => "Match",
+            Token::Enum => "Enum",
+            Token::Crate => "Crate",
+            Token::Simc => "Simc",
+            Token::Arrow => "Arrow",
+            Token::DoubleColon => "DoubleColon",
+            Token::Colon => "Colon",
+            Token::Semi => "Semi",
+            Token::Comma => "Comma",
+            Token::Eq => "Eq",
+            Token::FatArrow => "FatArrow",
+            Token::LParen => "LParen",
+            Token::RParen => "RParen",
+            Token::LBracket => "LBracket",
+            Token::RBracket => "RBracket",
+            Token::LBrace => "LBrace",
+            Token::RBrace => "RBrace",
+            Token::LAngle => "LAngle",
+            Token::RAngle => "RAngle",
+            Token::DecLiteral(_) => "DecLiteral",
+            Token::HexLiteral(_) => "HexLiteral",
+            Token::BinLiteral(_) => "BinLiteral",
+            Token::Bool(_) => "Bool",
+            Token::Ident(_) => "Ident",
+            Token::Jet(_) => "Jet",
+            Token::Witness(_) => "Witness",
+            Token::Param(_) => "Param",
+            Token::Macro(_) => "Macro",
+        }
+    }
+
+    /// Macro to assert that a sequence of tokens matches the expected variant types
+    macro_rules! assert_tokens_match {
+        ($tokens:expr, $($expected:ident),* $(,)?) => {
+            {
+                let tokens = $tokens.as_ref().expect("Expected Some tokens");
+                let expected_variants = vec![$( stringify!($expected) ),*];
+
+                assert_eq!(
+                    tokens.len(),
+                    expected_variants.len(),
+                    "Expected {} tokens, got {}.\nTokens: {:?}",
+                    expected_variants.len(),
+                    tokens.len(),
+                    tokens
+                );
+
+                for (idx, ((token, _span), expected_variant)) in tokens.iter().zip(expected_variants.iter()).enumerate() {
+                    let actual_variant = variant_name(token);
+                    assert_eq!(
+                        actual_variant,
+                        *expected_variant,
+                        "Token at index {} does not match: expected {}, got {} (token: {:?})",
+                        idx,
+                        expected_variant,
+                        actual_variant,
+                        token
+                    );
+                }
+            }
+        };
+    }
+
     fn lex<'src>(
         input: &'src str,
     ) -> (Option<Vec<Token<'src>>>, Vec<Rich<'src, char, SimpleSpan>>) {
@@ -808,6 +882,28 @@ mod original_lexer {
         let _ = tokens.unwrap();
 
         assert!(lex_errs.is_empty());
+    }
+
+    #[test]
+    fn test_lexer_padding_detection() {
+        let expr = "padding::<10>()";
+
+        let (tokens, lex_errs) = lexer().parse(expr).into_output_errors();
+
+        // let _ = tokens.unwrap();
+
+        assert!(lex_errs.is_empty());
+
+        assert_tokens_match!(
+            tokens,
+            Ident,
+            DoubleColon,
+            LAngle,
+            DecLiteral,
+            RAngle,
+            LParen,
+            RParen
+        );
     }
 }
 

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -475,6 +475,15 @@ pub struct Call {
 }
 
 impl Call {
+    /// Construct a call directly, bypassing the parser.
+    ///
+    /// Mirrors what `arbitrary` does for the fuzz targets, which build a
+    /// [`Program`] without going through the text parser.
+    #[cfg(test)]
+    pub(crate) fn new_unparsed(name: CallName, args: Arc<[Expression]>, span: Span) -> Self {
+        Self { name, args, span }
+    }
+
     /// Access the name of the call.
     pub fn name(&self) -> &CallName {
         &self.name
@@ -494,6 +503,16 @@ impl Call {
 impl_eq_hash!(Call; name, args);
 
 impl_require_feature!(Call {recurse: name, args; });
+
+/// Maximum number of layers that `padding::<N>()` may request.
+///
+/// Padding compiles to a chain of nodes whose depth is the layer count, and the rest
+/// of the compiler recurses over that depth, so an unbounded count overflows the stack.
+///
+/// At this limit a program compiles on the 8 MB main-thread stack in both debug and
+/// release, and on the 2 MB stack that spawned threads get by default in release. A
+/// debug build on a 2 MB thread stack is the one measured case that still runs out.
+pub const MAX_PADDING_SIZE: usize = 8192;
 
 /// Name of a call.
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
@@ -525,6 +544,9 @@ pub enum CallName {
     ArrayFold(FunctionName, NonZeroUsize),
     /// Loop over the given function a bounded number of times until it returns success.
     ForWhile(FunctionName),
+    /// Padding that inflates the program, raising the transaction weight so that
+    /// CPU-heavy programs fit in the budget. At most [`MAX_PADDING_SIZE`] layers.
+    Padding(NonZeroUsize),
 }
 
 impl_require_feature!(CallName {
@@ -542,6 +564,7 @@ impl_require_feature!(CallName {
         Fold(_, _),
         ArrayFold(_, _),
         ForWhile(_),
+        Padding(_),
 });
 
 /// A type alias.
@@ -1609,6 +1632,7 @@ impl fmt::Display for CallName {
             CallName::Fold(name, bound) => write!(f, "fold::<{name}, {bound}>"),
             CallName::ArrayFold(name, size) => write!(f, "array_fold::<{name}, {size}>"),
             CallName::ForWhile(name) => write!(f, "for_while::<{name}>"),
+            CallName::Padding(size) => write!(f, "padding::<{size}>"),
         }
     }
 }
@@ -2446,6 +2470,41 @@ impl ChumskyParse for CallName {
             Token::Macro("dbg!") => CallName::Debug,
         };
 
+        let padding = just(Token::Ident("padding"))
+            .ignore_then(turbofish_start.clone())
+            .then(select! { Token::DecLiteral(s) => s }.labelled("size"))
+            .then_ignore(generics_close.clone())
+            .validate(|((), size_str), e, emit| {
+                let size = match size_str.as_inner().parse::<usize>() {
+                    Ok(0) => {
+                        emit.emit(Error::PaddingSizeZero.with_span(e.span()));
+                        NonZeroUsize::new(1).unwrap()
+                    }
+                    Ok(n) if n > MAX_PADDING_SIZE => {
+                        emit.emit(
+                            Error::PaddingSizeTooLarge {
+                                size: n,
+                                max: MAX_PADDING_SIZE,
+                            }
+                            .with_span(e.span()),
+                        );
+                        NonZeroUsize::new(1).unwrap()
+                    }
+                    Ok(n) => NonZeroUsize::new(n).unwrap(),
+                    Err(_) => {
+                        emit.emit(
+                            Error::CannotParse {
+                                msg: format!("Invalid number: {size_str}"),
+                            }
+                            .with_span(e.span()),
+                        );
+                        NonZeroUsize::new(1).unwrap()
+                    }
+                };
+
+                CallName::Padding(size)
+            });
+
         let jet = select! { Token::Jet(s) => JetName::from_str_unchecked(s) }.map(CallName::Jet);
 
         let custom_func = FunctionName::parser().map(CallName::Custom);
@@ -2460,6 +2519,8 @@ impl ChumskyParse for CallName {
             for_while,
             simple_builtins,
             jet,
+            padding,
+            // Note: Add built-in functions before this, otherwise they will not be matched.
             custom_func,
         ))
     }
@@ -4324,6 +4385,83 @@ fn main() {
         assert!(
             error.contains("Missing ',' after a match arm that isn't block expression"),
             "expected the missing-comma diagnostic, got {error:?}"
+        );
+    }
+}
+
+#[cfg(test)]
+mod padding_tests {
+    use super::*;
+
+    /// Parse `input` and return the single `padding::<N>()` call it consists of.
+    fn parse_padding(input: &str) -> Result<Call, &'static str> {
+        let parsed = Expression::parse_from_str(input).map_err(|_| "Failed to parse")?;
+
+        match parsed.inner() {
+            ExpressionInner::Single(single) => match single.inner() {
+                SingleExpressionInner::Call(call) => match call.name() {
+                    CallName::Padding(_) => Ok(call.clone()),
+                    _ => Err("Expected a padding call"),
+                },
+                _ => Err("Expected a call expression"),
+            },
+            _ => Err("Expected a single expression"),
+        }
+    }
+
+    #[test]
+    fn test_parse_padding() {
+        let input = "padding::<10>()";
+
+        parse_padding(input).unwrap();
+    }
+
+    #[test]
+    fn test_parse_padding_accepts_max_size() {
+        let input = format!("padding::<{MAX_PADDING_SIZE}>()");
+
+        parse_padding(&input).unwrap();
+    }
+
+    #[test]
+    fn test_parse_padding_rejects_size_above_max() {
+        let input = format!("padding::<{}>()", MAX_PADDING_SIZE + 1);
+
+        let err = Expression::parse_from_str(&input)
+            .expect_err("padding above the maximum size should be rejected");
+
+        assert!(
+            matches!(
+                err.error(),
+                Error::PaddingSizeTooLarge {
+                    size,
+                    max: MAX_PADDING_SIZE
+                } if *size == MAX_PADDING_SIZE + 1
+            ),
+            "expected a PaddingSizeTooLarge diagnostic, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn test_parse_padding_rejects_zero() {
+        let err = Expression::parse_from_str("padding::<0>()")
+            .expect_err("padding of size zero should be rejected");
+
+        assert!(
+            matches!(err.error(), Error::PaddingSizeZero),
+            "expected a PaddingSizeZero diagnostic, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn test_parse_padding_should_fail_with_multiple_generics() {
+        let input = "padding::<10, 22>()";
+
+        let parsed_call = parse_padding(input);
+
+        assert!(
+            parsed_call.is_err(),
+            "padding parsed correctly but should have failed"
         );
     }
 }


### PR DESCRIPTION
This might be controversial, but I wanted to see if this was possible and what it might look like. 

The problem I'm aiming to solve is the [annex padding issue](https://github.com/BlockstreamResearch/simplicity/issues/290), which basically boils down to the transaction being padded with some data increase the budget for the CPU cost of the program.

It doesn't really make sense to increase the simplicity program size, however, developers who are unaware of this problem might add random code to the simplicity program. This adds formal syntax to SimplicityHL in the hopes that developers will find this keyword instead of adding random code. This allows us to remove this padding in future compilers cleanly.

A very common set of programs that need padding are ones using `for_while`.

Here is the example `hashloop` program 
```
fn main() {
    padding::<7369>();
 
   // Hash bytes 0x00 to 0xff
    let ctx: Ctx8 = jet::sha_256_ctx_8_init();
    let out: Either<u256, Ctx8> = for_while::<hash_counter_8>(ctx, ());
    let expected: u256 = 0x40aff2e9d2d8922e47afd4648e6967497158785fbd1da870e7110266bf944880;
    assert!(jet::eq_256(expected, unwrap_left::<Ctx8>(out)));
    
```

The addition of `padding` in this case avoids the error of "Program's execution cost could exceed budget" , however it is still not relayed due to `RPC error -26: min relay fee not met, 100 < 1226`, which I'll investigate further. This could just be some setting in `hal-simplicity` I am missing.

The instructions that `padding` adds at the moment are fairly arbitrary. If we decide to go ahead with this, I'm open to suggestions.

For this program (p2pkh.simf):
```rust 
fn sha2(string: u256) -> u256 {
    let hasher: Ctx8 = jet::sha_256_ctx_8_init();
    let hasher: Ctx8 = jet::sha_256_ctx_8_add_32(hasher, string);
    jet::sha_256_ctx_8_finalize(hasher)
}

fn main() {
    padding::<10>();
    let pk: Pubkey = witness::PK;
    let expected_pk_hash: u256 = 0x132f39a98c31baaddba6525f5d43f2954472097fa15265f45130bfdb70e51def; // sha2(1 * G)
    let pk_hash: u256 = sha2(pk);
    assert!(jet::eq_256(pk_hash, expected_pk_hash));

    let msg: u256 = jet::sig_all_hash();
    jet::bip_0340_verify((pk, msg), witness::SIG)
}

``` 

The program without padding:
```mermaid
flowchart TD
  node0["witness(0)"]
  node1["iden"]
  node2["pair"]
  node2 --> node0
  node2 --> node1
  node3["unit"]
  node4["word(0x132...1def)"]
  node5["comp"]
  node5 --> node3
  node5 --> node4
  node6["iden"]
  node7["pair"]
  node7 --> node5
  node7 --> node6
  node8["iden"]
  node9["take"]
  node9 --> node8
  node10["drop"]
  node10 --> node9
  node11["unit"]
  node12["jet(sha_256_ctx_8_init)"]
  node13["comp"]
  node13 --> node11
  node13 --> node12
  node14["iden"]
  node15["pair"]
  node15 --> node13
  node15 --> node14
  node16["iden"]
  node17["take"]
  node17 --> node16
  node18["iden"]
  node19["drop"]
  node19 --> node18
  node20["pair"]
  node20 --> node17
  node20 --> node19
  node21["jet(sha_256_ctx_8_add_32)"]
  node22["comp"]
  node22 --> node20
  node22 --> node21
  node23["iden"]
  node24["pair"]
  node24 --> node22
  node24 --> node23
  node25["iden"]
  node26["take"]
  node26 --> node25
  node27["jet(sha_256_ctx_8_finalize)"]
  node28["comp"]
  node28 --> node26
  node28 --> node27
  node29["comp"]
  node29 --> node24
  node29 --> node28
  node30["comp"]
  node30 --> node15
  node30 --> node29
  node31["comp"]
  node31 --> node10
  node31 --> node30
  node32["iden"]
  node33["pair"]
  node33 --> node31
  node33 --> node32
  node34["iden"]
  node35["take"]
  node35 --> node34
  node36["iden"]
  node37["take"]
  node37 --> node36
  node38["drop"]
  node38 --> node37
  node39["pair"]
  node39 --> node35
  node39 --> node38
  node40["jet(eq_256)"]
  node41["comp"]
  node41 --> node39
  node41 --> node40
  node42["jet(verify)"]
  node43["comp"]
  node43 --> node41
  node43 --> node42
  node44["unit"]
  node45["jet(sig_all_hash)"]
  node46["comp"]
  node46 --> node44
  node46 --> node45
  node47["iden"]
  node48["pair"]
  node48 --> node46
  node48 --> node47
  node49["iden"]
  node50["take"]
  node50 --> node49
  node51["drop"]
  node51 --> node50
  node52["drop"]
  node52 --> node51
  node53["drop"]
  node53 --> node52
  node54["iden"]
  node55["take"]
  node55 --> node54
  node56["pair"]
  node56 --> node53
  node56 --> node55
  node57["witness(57)"]
  node58["pair"]
  node58 --> node56
  node58 --> node57
  node59["jet(bip_0340_verify)"]
  node60["comp"]
  node60 --> node58
  node60 --> node59
  node61["comp"]
  node61 --> node48
  node61 --> node60
  node62["pair"]
  node62 --> node43
  node62 --> node61
  node63["iden"]
  node64["drop"]
  node64 --> node63
  node65["comp"]
  node65 --> node62
  node65 --> node64
  node66["comp"]
  node66 --> node33
  node66 --> node65
  node67["comp"]
  node67 --> node7
  node67 --> node66
  node68["comp"]
  node68 --> node2
  node68 --> node67

```

And with padding:
```mermaid
flowchart TD
  node0["unit"]
  node1["unit"]
  node2["unit"]
  node3["unit"]
  node4["unit"]
  node5["unit"]
  node6["unit"]
  node7["unit"]
  node8["unit"]
  node9["unit"]
  node10["unit"]
  node11["pair"]
  node11 --> node9
  node11 --> node10
  node12["iden"]
  node13["drop"]
  node13 --> node12
  node14["comp"]
  node14 --> node11
  node14 --> node13
  node15["pair"]
  node15 --> node8
  node15 --> node14
  node16["iden"]
  node17["drop"]
  node17 --> node16
  node18["comp"]
  node18 --> node15
  node18 --> node17
  node19["pair"]
  node19 --> node7
  node19 --> node18
  node20["iden"]
  node21["drop"]
  node21 --> node20
  node22["comp"]
  node22 --> node19
  node22 --> node21
  node23["pair"]
  node23 --> node6
  node23 --> node22
  node24["iden"]
  node25["drop"]
  node25 --> node24
  node26["comp"]
  node26 --> node23
  node26 --> node25
  node27["pair"]
  node27 --> node5
  node27 --> node26
  node28["iden"]
  node29["drop"]
  node29 --> node28
  node30["comp"]
  node30 --> node27
  node30 --> node29
  node31["pair"]
  node31 --> node4
  node31 --> node30
  node32["iden"]
  node33["drop"]
  node33 --> node32
  node34["comp"]
  node34 --> node31
  node34 --> node33
  node35["pair"]
  node35 --> node3
  node35 --> node34
  node36["iden"]
  node37["drop"]
  node37 --> node36
  node38["comp"]
  node38 --> node35
  node38 --> node37
  node39["pair"]
  node39 --> node2
  node39 --> node38
  node40["iden"]
  node41["drop"]
  node41 --> node40
  node42["comp"]
  node42 --> node39
  node42 --> node41
  node43["pair"]
  node43 --> node1
  node43 --> node42
  node44["iden"]
  node45["drop"]
  node45 --> node44
  node46["comp"]
  node46 --> node43
  node46 --> node45
  node47["pair"]
  node47 --> node0
  node47 --> node46
  node48["iden"]
  node49["drop"]
  node49 --> node48
  node50["comp"]
  node50 --> node47
  node50 --> node49
  node51["witness(51)"]
  node52["iden"]
  node53["pair"]
  node53 --> node51
  node53 --> node52
  node54["unit"]
  node55["word(0x132...1def)"]
  node56["comp"]
  node56 --> node54
  node56 --> node55
  node57["iden"]
  node58["pair"]
  node58 --> node56
  node58 --> node57
  node59["iden"]
  node60["take"]
  node60 --> node59
  node61["drop"]
  node61 --> node60
  node62["unit"]
  node63["jet(sha_256_ctx_8_init)"]
  node64["comp"]
  node64 --> node62
  node64 --> node63
  node65["iden"]
  node66["pair"]
  node66 --> node64
  node66 --> node65
  node67["iden"]
  node68["take"]
  node68 --> node67
  node69["iden"]
  node70["drop"]
  node70 --> node69
  node71["pair"]
  node71 --> node68
  node71 --> node70
  node72["jet(sha_256_ctx_8_add_32)"]
  node73["comp"]
  node73 --> node71
  node73 --> node72
  node74["iden"]
  node75["pair"]
  node75 --> node73
  node75 --> node74
  node76["iden"]
  node77["take"]
  node77 --> node76
  node78["jet(sha_256_ctx_8_finalize)"]
  node79["comp"]
  node79 --> node77
  node79 --> node78
  node80["comp"]
  node80 --> node75
  node80 --> node79
  node81["comp"]
  node81 --> node66
  node81 --> node80
  node82["comp"]
  node82 --> node61
  node82 --> node81
  node83["iden"]
  node84["pair"]
  node84 --> node82
  node84 --> node83
  node85["iden"]
  node86["take"]
  node86 --> node85
  node87["iden"]
  node88["take"]
  node88 --> node87
  node89["drop"]
  node89 --> node88
  node90["pair"]
  node90 --> node86
  node90 --> node89
  node91["jet(eq_256)"]
  node92["comp"]
  node92 --> node90
  node92 --> node91
  node93["jet(verify)"]
  node94["comp"]
  node94 --> node92
  node94 --> node93
  node95["unit"]
  node96["jet(sig_all_hash)"]
  node97["comp"]
  node97 --> node95
  node97 --> node96
  node98["iden"]
  node99["pair"]
  node99 --> node97
  node99 --> node98
  node100["iden"]
  node101["take"]
  node101 --> node100
  node102["drop"]
  node102 --> node101
  node103["drop"]
  node103 --> node102
  node104["drop"]
  node104 --> node103
  node105["iden"]
  node106["take"]
  node106 --> node105
  node107["pair"]
  node107 --> node104
  node107 --> node106
  node108["witness(108)"]
  node109["pair"]
  node109 --> node107
  node109 --> node108
  node110["jet(bip_0340_verify)"]
  node111["comp"]
  node111 --> node109
  node111 --> node110
  node112["comp"]
  node112 --> node99
  node112 --> node111
  node113["pair"]
  node113 --> node94
  node113 --> node112
  node114["iden"]
  node115["drop"]
  node115 --> node114
  node116["comp"]
  node116 --> node113
  node116 --> node115
  node117["comp"]
  node117 --> node84
  node117 --> node116
  node118["comp"]
  node118 --> node58
  node118 --> node117
  node119["comp"]
  node119 --> node53
  node119 --> node118
  node120["pair"]
  node120 --> node50
  node120 --> node119
  node121["iden"]
  node122["drop"]
  node122 --> node121
  node123["comp"]
  node123 --> node120
  node123 --> node122


```
