### PR TITLE
Allow multidep enums

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -1196,9 +1196,11 @@ impl Scope {
     /// An enum is a type alias for a nominal enum type, so its name resolves as a type
     /// and its identity travels wherever the alias is imported.
     ///
-    /// Enums may only be declared at the top level of the program's own files
-    /// (the parser rejects declarations inside `mod` blocks, the driver rejects them in dependency files),
-    /// so the bare name is unique program-wide and identifies the enum in the ABI.
+    /// Identity is the declaration site, not the written name: `file_id` is the
+    /// source file the declaration came from, and it participates in the type's
+    /// equality. Two files may therefore each declare an `Action` without the
+    /// two becoming one type. `name` stays a display string, which is what
+    /// diagnostics print and what witness and argument files write.
     ///
     /// ## Errors
     ///
@@ -1208,10 +1210,11 @@ impl Scope {
         name: AliasName,
         visibility: Visibility,
         variants: Arc<[EnumVariantInfo]>,
+        span: Span,
     ) -> Result<(), Error> {
         self.check_alias_free(&name)?;
 
-        let info = EnumInfo::new(Arc::clone(name.as_inner()), variants);
+        let info = EnumInfo::new(Arc::clone(name.as_inner()), variants, span);
         let resolved = ResolvedType::enumeration(info);
 
         self.current_module_mut()
@@ -1458,7 +1461,12 @@ impl AbstractSyntaxTree for Item {
                     })
                     .collect::<Result<Arc<[EnumVariantInfo]>, Diagnostic>>()?;
                 scope
-                    .insert_enum(decl.name().clone(), decl.visibility().clone(), variants)
+                    .insert_enum(
+                        decl.name().clone(),
+                        decl.visibility().clone(),
+                        variants,
+                        *decl.span(),
+                    )
                     .with_span(decl)?;
 
                 Ok(Self::EnumDeclaration)
@@ -3268,45 +3276,6 @@ mod enum_tests {
              fn main() {}",
         );
         assert!(result.is_err(), "redefined enum name should error");
-    }
-
-    #[test]
-    fn enum_declaration_inside_module_errors() {
-        // FIXME: Enums may only be declared at the top level of a file.
-        let result = analyze(
-            "mod m {
-                 pub enum Choice { X, Y, }
-             }
-             fn main() {}",
-        );
-        let err = result.expect_err("enum inside `mod` must be rejected");
-        assert!(
-            err.contains("top level"),
-            "error should say enums are top-level only: {err}"
-        );
-    }
-
-    #[test]
-    fn enum_declaration_in_dependency_errors() {
-        use crate::ast::scope_resolution_tests::analyze_multifile;
-
-        // FIXME: An enum's declared name is its identity in the ABI, so enums may only be declared in the program's own files.
-        let result = analyze_multifile(vec![
-            (
-                "main.simf",
-                "use lib::A::helper;
-                 fn main() { helper(); }",
-            ),
-            (
-                "libs/lib/A.simf",
-                "pub enum Status { On, Off, } pub fn helper() {}",
-            ),
-        ]);
-        let err = result.expect_err("enums in dependency files must be rejected");
-        assert!(
-            err.contains("dependency"),
-            "error should say enums cannot live in dependency files: {err}"
-        );
     }
 
     #[test]

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -1214,7 +1214,12 @@ impl Scope {
     ) -> Result<(), Error> {
         self.check_alias_free(&name)?;
 
-        let info = EnumInfo::new(Arc::clone(name.as_inner()), variants, span);
+        let info = EnumInfo::new(
+            Arc::clone(name.as_inner()),
+            variants,
+            span,
+            Arc::from(self.module_path.clone()),
+        );
         let resolved = ResolvedType::enumeration(info);
 
         self.current_module_mut()

--- a/src/driver/resolve_order.rs
+++ b/src/driver/resolve_order.rs
@@ -5,56 +5,6 @@ use crate::error::{Diagnostic, DiagnosticManager, Error, Span};
 use crate::parse::{self, Visibility};
 use crate::str::{Identifier, ModuleName};
 
-/// All enum declarations among `items`, recursing into `mod` blocks.
-fn enum_declarations(items: &[parse::Item]) -> Vec<&parse::EnumDeclaration> {
-    let mut found = Vec::new();
-    for item in items {
-        match item {
-            parse::Item::EnumDeclaration(decl) => found.push(decl),
-            parse::Item::Module(module) => found.extend(enum_declarations(module.items())),
-            _ => {}
-        }
-    }
-    found
-}
-
-// TODO: allow enums in deps when mentioned problems are resolved
-/// Enums by design are nominative, therefore to reason about same named enums in different modules
-/// we have to have a stable ABI with the suport of "qualified name".
-/// Currently, there is no support of "qualified name" concpet, therefore at the time of creating
-/// enums, it is forbidden to decler them in dependencies.
-///
-/// If we used current ABI we would face following problems:
-/// 1. Adding or removing an unrelated dependency renumbers the files, so the same enum's ABI
-///    name changes between builds even though no source changed.
-///    The whole point of "identity is the qualified name" is that serialized forms can identify an enum across builds.
-/// 2. Unwritable witness files. A user filling in a witness would have
-///    to write `unit_2::Action::Cold` (a name that appears nowhere in their source and that they can't predict).
-/// 3. Meaningless nominal distinctness. `a::Action` vs `b::Action` being distinct types only makes
-///    sense if a and b are the user's module names, not compiler-generated counters.
-fn forbid_enum_dec_in_deps(
-    source_id: usize,
-    local_items: &[parse::Item],
-    diagnostics: &mut DiagnosticManager,
-) {
-    if source_id == MAIN_MODULE {
-        return;
-    }
-
-    for decl in enum_declarations(local_items) {
-        diagnostics.push(Diagnostic::new(
-            Error::Grammar {
-                msg: format!(
-                    "enum `{}` is declared in a dependency file; \
-                     enums may only be declared in the program's own files",
-                    decl.name()
-                ),
-            },
-            *decl.as_ref(),
-        ));
-    }
-}
-
 /// This is a core component of the [`DependencyGraph`].
 impl DependencyGraph {
     /// Resolves the dependency graph and constructs the final AST program.
@@ -113,14 +63,6 @@ impl DependencyGraph {
                 }
             }
 
-            forbid_enum_dec_in_deps(source_id, &local_items, diagnostics);
-
-            // TODO(enums): the flattened output wraps every file — the
-            // entry file included — in a generated module, but enum
-            // declarations are only valid at the top level of a file, so
-            // flattening an enum program produces source that no longer
-            // re-parses (`TemplateAst::flatten`). Splice the entry
-            // file's items at the root instead of wrapping them.
             let name = ModuleName::from_ident(&Self::get_module_name(source_id));
             items.push(parse::Item::Module(parse::Module::new(
                 source_id,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,8 @@
 //! Library for parsing and compiling SimplicityHL
 
+use std::collections::HashMap;
+use std::fmt;
+
 pub mod array;
 pub mod ast;
 pub mod compile;
@@ -400,10 +403,29 @@ impl CompiledProgram {
 /// encoding and the CMR while leaving the ABI text identical). Such
 /// consumers need the program source or another artifact carrying the enum
 /// schema.
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 pub struct AbiMeta {
     pub witness_types: WitnessTypes,
     pub param_types: Parameters,
+}
+
+impl fmt::Debug for AbiMeta {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let witness_types: HashMap<_, _> = self
+            .witness_types
+            .iter()
+            .map(|(name, ty)| (name.clone(), ty.abi_description()))
+            .collect();
+        let param_types: HashMap<_, _> = self
+            .param_types
+            .iter()
+            .map(|(name, ty)| (name.clone(), ty.abi_description()))
+            .collect();
+        f.debug_struct("AbiMeta")
+            .field("witness_types", &witness_types)
+            .field("param_types", &param_types)
+            .finish()
+    }
 }
 
 /// A SimplicityHL program, compiled to Simplicity and satisfied with witness data.
@@ -1684,6 +1706,71 @@ fn main() {
                 .contains("Expected expression of type `Action`, found type `Action`"),
             "expected a nominal type mismatch, got:\n{err}"
         );
+    }
+
+    #[test]
+    fn abi_description_cannot_distinguish_two_same_shaped_enums_yet() {
+        // Two enums, same name and same variant shapes, declared in
+        // different modules: distinct nominal types (see
+        // `enum_same_name_in_two_modules_are_distinct_types`), each used at
+        // its own type here, so this compiles.
+        //
+        // TODO(follow-up): once `EnumInfo` carries a declaration path,
+        // these two should render differently (e.g. `door::Action { .. }`
+        // vs `wallet::Action { .. }`).
+        let ws = TempWorkspace::new("abi_same_shaped_enums");
+        let root = ws.create_dir("workspace");
+        let main_path = ws.create_file(
+            format!("workspace/{MAIN}").as_str(),
+            "mod door {
+                pub enum Action { Open, Close(u32), }
+                pub fn describe(a: Action) -> u32 {
+                    match a { Action::Open => 1, Action::Close(n: u32) => n, }
+                }
+            }
+            mod wallet {
+                pub enum Action { Open, Close(u32), }
+                pub fn spend(a: Action) -> u32 {
+                    match a { Action::Open => 100, Action::Close(n: u32) => n, }
+                }
+            }
+            use crate::door::{Action as DoorAction, describe};
+            use crate::wallet::{Action as WalletAction, spend};
+            fn main() {
+                let dact: DoorAction = witness::DOOR_ACTION;
+                let wact: WalletAction = witness::WALLET_ACTION;
+                assert!(jet::eq_32(describe(dact), 1));
+                assert!(jet::eq_32(spend(wact), 100));
+            }",
+        );
+
+        let canon_root = CanonPath::canonicalize(&root).unwrap();
+        let dependencies = build_map(&canon_root, &[]).unwrap();
+        let source = CanonSourceFile::new(
+            CanonPath::canonicalize(&main_path).unwrap(),
+            Arc::from(std::fs::read_to_string(&main_path).unwrap()),
+        );
+
+        let template = TemplateAst::new_with_dep(
+            source,
+            &dependencies,
+            &UnstableFeatures::all(),
+            Box::new(ElementsJetHinter::new()),
+        )
+        .expect("two distinct enums used at their own type must compile");
+
+        let abi = template.generate_abi_meta().unwrap();
+        let door = abi
+            .witness_types
+            .get(&TemplateProgramWitness::witness_from_str("DOOR_ACTION"))
+            .expect("DOOR_ACTION must be recorded");
+        let wallet = abi
+            .witness_types
+            .get(&TemplateProgramWitness::witness_from_str("WALLET_ACTION"))
+            .expect("WALLET_ACTION must be recorded");
+
+        assert_eq!(door.abi_description(), wallet.abi_description());
+        assert_eq!(door.abi_description(), "Action { Open, Close(u32) }");
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -428,6 +428,53 @@ impl fmt::Debug for AbiMeta {
     }
 }
 
+impl AbiMeta {
+    /// Same as `abi_description`, except an enum type is prefixed with the
+    /// absolute path of the file. It acts like unique identifier for nominative type
+    pub fn describe(
+        &self,
+        sources: Option<&SourceMap>,
+    ) -> (HashMap<String, String>, HashMap<String, String>) {
+        let describe_one = |ty: &types::ResolvedType| -> String {
+            let base = ty.abi_description();
+            let (Some(info), Some(sources)) = (ty.as_enum(), sources) else {
+                return base;
+            };
+            let Some(path) = sources.path(info.span().file_id) else {
+                return base;
+            };
+
+            let modules = info
+                .module_path()
+                .get(1..) // drop the driver-assigned `unit_N` segment
+                .unwrap_or(&[])
+                .iter()
+                .map(|m| m.as_str())
+                .collect::<Vec<_>>()
+                .join("::");
+
+            let file = path.as_path().display();
+            if modules.is_empty() {
+                format!("{file}: {base}")
+            } else {
+                format!("{file}::{modules}: {base}")
+            }
+        };
+
+        let witness_types = self
+            .witness_types
+            .iter()
+            .map(|(name, ty)| (name.as_str().to_string(), describe_one(ty)))
+            .collect();
+        let param_types = self
+            .param_types
+            .iter()
+            .map(|(name, ty)| (name.as_str().to_string(), describe_one(ty)))
+            .collect();
+        (witness_types, param_types)
+    }
+}
+
 /// A SimplicityHL program, compiled to Simplicity and satisfied with witness data.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct SatisfiedProgram {
@@ -1709,15 +1756,11 @@ fn main() {
     }
 
     #[test]
-    fn abi_description_cannot_distinguish_two_same_shaped_enums_yet() {
+    fn abi_description_bare_vs_qualified_for_two_same_shaped_enums() {
         // Two enums, same name and same variant shapes, declared in
         // different modules: distinct nominal types (see
         // `enum_same_name_in_two_modules_are_distinct_types`), each used at
         // its own type here, so this compiles.
-        //
-        // TODO(follow-up): once `EnumInfo` carries a declaration path,
-        // these two should render differently (e.g. `door::Action { .. }`
-        // vs `wallet::Action { .. }`).
         let ws = TempWorkspace::new("abi_same_shaped_enums");
         let root = ws.create_dir("workspace");
         let main_path = ws.create_file(
@@ -1769,8 +1812,37 @@ fn main() {
             .get(&TemplateProgramWitness::witness_from_str("WALLET_ACTION"))
             .expect("WALLET_ACTION must be recorded");
 
+        // The bare form is intentionally shape-only: same name, same
+        // variants, so identical text either way.
         assert_eq!(door.abi_description(), wallet.abi_description());
         assert_eq!(door.abi_description(), "Action { Open, Close(u32) }");
+
+        // Qualified by declaration site, the two must render distinctly.
+        let sources = template
+            .source_map()
+            .expect("a driver-compiled program has a source map");
+        let (witness_types, _) = abi.describe(Some(sources));
+        let door_q = witness_types.get("DOOR_ACTION").expect("recorded above");
+        let wallet_q = witness_types.get("WALLET_ACTION").expect("recorded above");
+
+        dbg!(door_q, wallet_q);
+
+        assert_ne!(
+            door_q, wallet_q,
+            "distinct declarations must render distinctly once qualified"
+        );
+        assert!(
+            door_q.ends_with("::door: Action { Open, Close(u32) }"),
+            "got {door_q}"
+        );
+        assert!(
+            wallet_q.ends_with("::wallet: Action { Open, Close(u32) }"),
+            "got {wallet_q}"
+        );
+        assert!(
+            !door_q.contains("unit_0") && !wallet_q.contains("unit_0"),
+            "the driver-assigned segment must not leak into the qualified form: {door_q} / {wallet_q}"
+        );
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1602,24 +1602,88 @@ fn main() {
 
     #[test]
     fn enum_construction_compiles_and_runs() {
-        let src = "enum Action { Refresh(u32, bool), Cold, }
-             fn pick() -> Action {
-                 Action::Refresh(7, true)
-             }
-             fn main() {
-                 let a: Action = pick();
-                 match a {
-                     Action::Refresh(n: u32, b: bool) => {
-                         assert!(jet::eq_32(n, 7));
-                         assert!(b);
-                     },
-                     Action::Cold => assert!(false),
-                 }
-             }";
+        let ws = TempWorkspace::new("crate_success");
+        let root = ws.create_dir("workspace");
+        ws.create_file(
+            format!("workspace/{MAIN}").as_str(),
+            "enum Action { Refresh(u32, bool), Cold, }
+            fn pick() -> Action {
+                Action::Refresh(7, true)
+            }
+            fn main() {
+                let a: Action = pick();
+                match a {
+                    Action::Refresh(n: u32, b: bool) => {
+                        assert!(jet::eq_32(n, 7));
+                        assert!(b);
+                    },
+                    Action::Cold => assert!(false),
+                }
+            }",
+        );
 
-        TestCase::program_text_with_unstable(Cow::Borrowed(src), UnstableFeatures::all())
-            .with_witness_values(WitnessValues::default())
-            .assert_run_success();
+        let main_path = root.join(MAIN);
+        let canon_root = CanonPath::canonicalize(&root).unwrap();
+        let dependency_map = build_map(&canon_root, &[]).unwrap();
+
+        TestCase::<TemplateAst>::template_deps_with_unstable(
+            &main_path,
+            &dependency_map,
+            UnstableFeatures::all(),
+        )
+        .with_arguments(Arguments::default())
+        .with_witness_values(WitnessValues::default())
+        .assert_run_success();
+    }
+
+    #[test]
+    fn enum_same_name_in_two_modules_are_distinct_types() {
+        let ws = TempWorkspace::new("enum_nominal_identity");
+        let root = ws.create_dir("workspace");
+        let main_path = ws.create_file(
+            format!("workspace/{MAIN}").as_str(),
+            "mod door {
+                pub enum Action { Open, Close, }
+                pub fn describe(a: Action) -> u32 {
+                    match a { Action::Open => 1, Action::Close => 2, }
+                }
+            }
+            mod wallet {
+                pub enum Action { Open, Close, }
+                pub fn spend(a: Action) -> u32 {
+                    match a { Action::Open => 100, Action::Close => 200, }
+                }
+            }
+            use crate::door::Action as DoorAction;
+            use crate::wallet::spend;
+            fn main() {
+                let d: DoorAction = DoorAction::Open;
+                assert!(jet::eq_32(spend(d), 100));
+            }",
+        );
+
+        let canon_root = CanonPath::canonicalize(&root).unwrap();
+        let dependencies = build_map(&canon_root, &[]).unwrap();
+        let source = CanonSourceFile::new(
+            CanonPath::canonicalize(&main_path).unwrap(),
+            Arc::from(std::fs::read_to_string(&main_path).unwrap()),
+        );
+
+        let err = TemplateAst::new_with_dep(
+            source,
+            &dependencies,
+            &UnstableFeatures::all(),
+            Box::new(ElementsJetHinter::new()),
+        )
+        .expect_err("`door::Action` must not satisfy a `wallet::Action` parameter");
+
+        // TODO: both types display as `Action`, so the message cannot be acted on.
+        // Print the declaring module path and point at both declaration sites.
+        assert!(
+            err.to_string()
+                .contains("Expected expression of type `Action`, found type `Action`"),
+            "expected a nominal type mismatch, got:\n{err}"
+        );
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,12 +6,23 @@ use simplicityhl::ast::ElementsJetHinter;
 use simplicityhl::error::should_color;
 use simplicityhl::version::SimcDirective;
 use simplicityhl::{
-    resolution::DependencyMapBuilder, source::CanonPath, source::CanonSourceFile, AbiMeta,
-    TemplateAst,
+    resolution::DependencyMapBuilder, source::CanonPath, source::CanonSourceFile, TemplateAst,
 };
 use simplicityhl::{UnstableFeature, UnstableFeatures};
+use std::collections::HashMap;
 use std::path::Path;
 use std::{env, fmt, io};
+
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
+#[cfg_attr(not(feature = "serde"), allow(dead_code))]
+#[derive(Debug)]
+/// ABI metadata rendered for display: each witness/parameter type as text,
+/// with enum types qualified by their real declaration path.
+struct AbiOutput {
+    witness_types: HashMap<String, String>,
+    #[cfg_attr(feature = "serde", serde(rename = "parameter_types"))]
+    param_types: HashMap<String, String>,
+}
 
 #[cfg_attr(feature = "serde", derive(serde::Serialize))]
 /// The compilation output.
@@ -21,7 +32,7 @@ struct Output {
     /// Simplicity witness result, base64 encoded, if the .wit file was provided.
     witness: Option<String>,
     /// Simplicity program ABI metadata to the program which the user provides.
-    abi_meta: Option<AbiMeta>,
+    abi_meta: Option<AbiOutput>,
     /// Commitment Merkle Root (CMR) of the program, hex encoded.
     cmr: String,
     /// Version of the compiler that produced this output. Different compiler
@@ -293,7 +304,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     };
 
     let abi_opt = if abi_param {
-        Some(compiled.generate_abi_meta()?)
+        let abi = compiled.generate_abi_meta()?;
+        let (witness_types, param_types) = abi.describe(template.source_map());
+        Some(AbiOutput {
+            witness_types,
+            param_types,
+        })
     } else {
         None
     };

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -3114,27 +3114,6 @@ impl Module {
                 items,
                 span: e.span(),
             })
-            .validate(|module, _, emit| {
-                // TODO: Enums may only be declared at the top level of a file (done so to reduce scope of the PR).
-                // The bare name is the enum's identity in the ABI, and a module path would obscure it.
-                // Direct children suffice. Nested modules validate their own items.
-                for item in module.items.iter() {
-                    if let Item::EnumDeclaration(decl) = item {
-                        emit.emit(
-                            Error::Grammar {
-                                msg: format!(
-                                    "enum `{}` is declared inside `mod {}`; enums may \
-                                     only be declared at the top level of a file",
-                                    decl.name(),
-                                    module.name
-                                ),
-                            }
-                            .with_span(decl.into()),
-                        );
-                    }
-                }
-                module
-            })
     }
 }
 

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -128,9 +128,20 @@ impl Serialize for AbiMeta {
     {
         use ::serde::ser::SerializeStruct;
 
+        let witness_types: HashMap<_, _> = self
+            .witness_types
+            .iter()
+            .map(|(name, ty)| (name.as_str(), ty.abi_description()))
+            .collect();
+        let param_types: HashMap<_, _> = self
+            .param_types
+            .iter()
+            .map(|(name, ty)| (name.as_str(), ty.abi_description()))
+            .collect();
+
         let mut state = serializer.serialize_struct("AbiMeta", 2)?;
-        state.serialize_field("witness_types", &self.witness_types)?;
-        state.serialize_field("parameter_types", &self.param_types)?;
+        state.serialize_field("witness_types", &witness_types)?;
+        state.serialize_field("parameter_types", &param_types)?;
         state.end()
     }
 }

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -330,6 +330,7 @@ impl Serialize for Arguments {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::error::Span;
     use crate::str::Identifier;
 
     #[test]
@@ -345,7 +346,7 @@ mod tests {
         }
     }
 
-    fn unit_enum(name: &str, variants: &[&str]) -> ResolvedType {
+    fn unit_enum(name: &str, variants: &[&str], span: Span) -> ResolvedType {
         use crate::types::{EnumInfo, EnumVariantInfo};
         use std::sync::Arc;
 
@@ -353,14 +354,14 @@ mod tests {
             .iter()
             .map(|name| EnumVariantInfo::new(Identifier::from_str_unchecked(name), Arc::from([])))
             .collect();
-        ResolvedType::enumeration(EnumInfo::new(Arc::from(name), variants))
+        ResolvedType::enumeration(EnumInfo::new(Arc::from(name), variants, span))
     }
 
     #[test]
     fn abi_enum_type_serializes_as_name() {
         use crate::types::TypeConstructible;
 
-        let action_ty = unit_enum("Action", &["Inherit", "ColdSpend"]);
+        let action_ty = unit_enum("Action", &["Inherit", "ColdSpend"], Span::DUMMY);
         let witness_types = WitnessTypes::from(HashMap::from([
             (
                 TemplateProgramWitness::witness_from_str("ACTION"),
@@ -372,7 +373,10 @@ mod tests {
             ),
             (
                 TemplateProgramWitness::witness_from_str("PAIR"),
-                ResolvedType::tuple([action_ty, unit_enum("Reaction", &["Fast", "Slow"])]),
+                ResolvedType::tuple([
+                    action_ty,
+                    unit_enum("Reaction", &["Fast", "Slow"], Span::DUMMY),
+                ]),
             ),
             (
                 TemplateProgramWitness::witness_from_str("PLAIN"),
@@ -389,7 +393,7 @@ mod tests {
 
     #[test]
     fn enum_witness_value_serializes_as_variant_name() {
-        let action_ty = unit_enum("Action", &["Inherit", "ColdSpend"]);
+        let action_ty = unit_enum("Action", &["Inherit", "ColdSpend"], Span::DUMMY);
         let value = Value::enum_variant(
             &action_ty,
             &Identifier::from_str_unchecked("ColdSpend"),
@@ -438,7 +442,8 @@ mod tests {
                 Arc::from([u32_ty.clone()]),
             ),
         ]);
-        let action_ty = ResolvedType::enumeration(EnumInfo::new(Arc::from("Action"), variants));
+        let action_ty =
+            ResolvedType::enumeration(EnumInfo::new(Arc::from("Action"), variants, Span::DUMMY));
         let value = Value::enum_variant(
             &action_ty,
             &Identifier::from_str_unchecked("Refresh"),
@@ -469,7 +474,7 @@ mod tests {
         use crate::types::TypeConstructible;
         use crate::value::ValueConstructible;
 
-        let action_ty = unit_enum("Action", &["Hot", "Cold"]);
+        let action_ty = unit_enum("Action", &["Hot", "Cold"], Span::DUMMY);
         let option_ty = ResolvedType::option(action_ty.clone());
         let cold = Value::enum_variant(&action_ty, &Identifier::from_str_unchecked("Cold"), vec![])
             .unwrap();

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -365,7 +365,12 @@ mod tests {
             .iter()
             .map(|name| EnumVariantInfo::new(Identifier::from_str_unchecked(name), Arc::from([])))
             .collect();
-        ResolvedType::enumeration(EnumInfo::new(Arc::from(name), variants, span))
+        ResolvedType::enumeration(EnumInfo::new(
+            Arc::from(name),
+            variants,
+            span,
+            Arc::from([]),
+        ))
     }
 
     #[test]
@@ -453,8 +458,12 @@ mod tests {
                 Arc::from([u32_ty.clone()]),
             ),
         ]);
-        let action_ty =
-            ResolvedType::enumeration(EnumInfo::new(Arc::from("Action"), variants, Span::DUMMY));
+        let action_ty = ResolvedType::enumeration(EnumInfo::new(
+            Arc::from("Action"),
+            variants,
+            Span::DUMMY,
+            Arc::from([]),
+        ));
         let value = Value::enum_variant(
             &action_ty,
             &Identifier::from_str_unchecked("Refresh"),

--- a/src/types/aliased.rs
+++ b/src/types/aliased.rs
@@ -127,7 +127,7 @@ impl AliasedType {
                     }
                     // There is no syntax for writing an enum type inline (enums enter aliased types only by name)
                     TypeInner::Enum(info) => {
-                        output.push(ResolvedType::enumeration(info.clone()));
+                        output.push(ResolvedType(TypeInner::Enum(Arc::clone(info))));
                     }
                 },
             }

--- a/src/types/inner.rs
+++ b/src/types/inner.rs
@@ -2,6 +2,7 @@ use core::fmt;
 use core::str::FromStr;
 use std::sync::Arc;
 
+use crate::error::Span;
 use crate::num::{NonZeroPow2Usize, Pow2Usize};
 use crate::str::Identifier;
 
@@ -27,7 +28,7 @@ pub enum TypeInner<A> {
     List(A, NonZeroPow2Usize),
     /// Nominal enum type, represented as a balanced sum of its variants'
     /// payload types
-    Enum(EnumInfo),
+    Enum(Arc<EnumInfo>),
 }
 
 impl<A> TypeInner<A> {
@@ -234,6 +235,7 @@ impl FromStr for UIntType {
 pub struct EnumInfo {
     name: Arc<str>,
     variants: Arc<[EnumVariantInfo]>,
+    span: Span,
 }
 
 impl EnumInfo {
@@ -242,9 +244,13 @@ impl EnumInfo {
     /// `variants` must not be empty: a sum of zero types would be
     /// uninhabited, which Simplicity's type algebra cannot express.
     /// A single-variant enum is a named wrapper of its payload.
-    pub(crate) fn new(name: Arc<str>, variants: Arc<[EnumVariantInfo]>) -> Self {
+    pub(crate) fn new(name: Arc<str>, variants: Arc<[EnumVariantInfo]>, span: Span) -> Self {
         debug_assert!(!variants.is_empty());
-        Self { name, variants }
+        Self {
+            name,
+            variants,
+            span,
+        }
     }
 
     /// Access the declared name of the enum.

--- a/src/types/inner.rs
+++ b/src/types/inner.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use crate::error::Span;
 use crate::num::{NonZeroPow2Usize, Pow2Usize};
-use crate::str::Identifier;
+use crate::str::{Identifier, ModuleName};
 
 use super::{ResolvedType, StructuralType, TypeConstructible as _};
 
@@ -228,14 +228,15 @@ impl FromStr for UIntType {
 /// unrepresentable. A variant's position among the declared variants
 /// determines its leaf in the sum; there is no separate discriminant.
 ///
-/// Identity is the declared name: enums may only be declared at the top
-/// level of the program's own files, so the name is unique program-wide and
-/// serialized forms (such as the ABI) can identify an enum by it.
+/// Identity is the declaration site (`span`), not the written name: two
+/// files may each declare an `Action` without the two becoming one type.
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
 pub struct EnumInfo {
     name: Arc<str>,
     variants: Arc<[EnumVariantInfo]>,
     span: Span,
+    /// Need it to retrieve actual path to unique `EnumInfo`.
+    module_path: Arc<[ModuleName]>,
 }
 
 impl EnumInfo {
@@ -244,18 +245,33 @@ impl EnumInfo {
     /// `variants` must not be empty: a sum of zero types would be
     /// uninhabited, which Simplicity's type algebra cannot express.
     /// A single-variant enum is a named wrapper of its payload.
-    pub(crate) fn new(name: Arc<str>, variants: Arc<[EnumVariantInfo]>, span: Span) -> Self {
+    pub(crate) fn new(
+        name: Arc<str>,
+        variants: Arc<[EnumVariantInfo]>,
+        span: Span,
+        module_path: Arc<[ModuleName]>,
+    ) -> Self {
         debug_assert!(!variants.is_empty());
         Self {
             name,
             variants,
             span,
+            module_path,
         }
     }
 
     /// Access the declared name of the enum.
     pub fn name(&self) -> &str {
         &self.name
+    }
+
+    /// The module chain the declaration sits in, root first.
+    pub fn module_path(&self) -> &[ModuleName] {
+        &self.module_path
+    }
+
+    pub fn span(&self) -> &Span {
+        &self.span
     }
 
     /// Access the variants of the enum in declaration order.

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -154,6 +154,7 @@ mod tests {
             Arc::from("Test"),
             Arc::from([unit, single, pair]),
             Span::DUMMY,
+            Arc::from([]),
         );
         assert_eq!("Test", info.name());
         assert_eq!(3, info.structural_variants().len());

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -107,7 +107,7 @@ pub trait TypeDeconstructible: Sized {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::str::Identifier;
+    use crate::{error::Span, str::Identifier};
 
     #[test]
     fn display_type() {
@@ -150,7 +150,11 @@ mod tests {
             pair.payload_type()
         );
 
-        let info = EnumInfo::new(Arc::from("Test"), Arc::from([unit, single, pair]));
+        let info = EnumInfo::new(
+            Arc::from("Test"),
+            Arc::from([unit, single, pair]),
+            Span::DUMMY,
+        );
         assert_eq!("Test", info.name());
         assert_eq!(3, info.structural_variants().len());
         let (index, variant) = info

--- a/src/types/resolved.rs
+++ b/src/types/resolved.rs
@@ -43,6 +43,34 @@ impl ResolvedType {
         }
     }
 
+    /// Full description for the ABI: an enum expands into its variants and
+    /// their payload types; every other type is unchanged from [`Display`].
+    pub(crate) fn abi_description(&self) -> String {
+        let Some(info) = self.as_enum() else {
+            return self.to_string();
+        };
+
+        let variants = info
+            .variants()
+            .iter()
+            .map(|v| {
+                if v.payload().is_empty() {
+                    v.name().to_string()
+                } else {
+                    let payload = v
+                        .payload()
+                        .iter()
+                        .map(ToString::to_string)
+                        .collect::<Vec<_>>()
+                        .join(", ");
+                    format!("{}({})", v.name(), payload)
+                }
+            })
+            .collect::<Vec<_>>()
+            .join(", ");
+        format!("{} {{ {} }}", info.name(), variants)
+    }
+
     /// Check whether the type mentions an enum, at any nesting depth.
     pub fn contains_enum(&self) -> bool {
         self.post_order_iter()

--- a/src/types/resolved.rs
+++ b/src/types/resolved.rs
@@ -10,7 +10,7 @@ use crate::num::NonZeroPow2Usize;
 
 /// SimplicityHL type without type aliases.
 #[derive(PartialEq, Eq, Hash, Clone)]
-pub struct ResolvedType(TypeInner<Arc<Self>>);
+pub struct ResolvedType(pub(super) TypeInner<Arc<Self>>);
 
 impl ResolvedType {
     /// Access the inner type primitive.
@@ -31,12 +31,12 @@ impl ResolvedType {
 /// (which owns the uniqueness of declaration ids) can mint enum types.
 impl ResolvedType {
     /// Create a nominal enum type from the given definition.
-    pub const fn enumeration(info: EnumInfo) -> Self {
-        Self(TypeInner::Enum(info))
+    pub fn enumeration(info: EnumInfo) -> Self {
+        Self(TypeInner::Enum(Arc::new(info)))
     }
 
     /// Access the enum definition if this is an enum type.
-    pub const fn as_enum(&self) -> Option<&EnumInfo> {
+    pub fn as_enum(&self) -> Option<&EnumInfo> {
         match &self.0 {
             TypeInner::Enum(info) => Some(info),
             _ => None,

--- a/src/types/resolved.rs
+++ b/src/types/resolved.rs
@@ -43,6 +43,12 @@ impl ResolvedType {
         }
     }
 
+    /// Check whether the type mentions an enum, at any nesting depth.
+    pub fn contains_enum(&self) -> bool {
+        self.post_order_iter()
+            .any(|data| data.node.as_enum().is_some())
+    }
+
     /// Full description for the ABI: an enum expands into its variants and
     /// their payload types; every other type is unchanged from [`Display`].
     pub(crate) fn abi_description(&self) -> String {
@@ -69,12 +75,6 @@ impl ResolvedType {
             .collect::<Vec<_>>()
             .join(", ");
         format!("{} {{ {} }}", info.name(), variants)
-    }
-
-    /// Check whether the type mentions an enum, at any nesting depth.
-    pub fn contains_enum(&self) -> bool {
-        self.post_order_iter()
-            .any(|data| data.node.as_enum().is_some())
     }
 }
 

--- a/src/value.rs
+++ b/src/value.rs
@@ -1398,6 +1398,7 @@ mod destruct {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::error::Span;
     use crate::parse;
     use crate::types::{EnumInfo, EnumVariantInfo, StructuralType, TypeConstructible};
 
@@ -1412,7 +1413,7 @@ mod tests {
             })
             .collect();
 
-        ResolvedType::enumeration(EnumInfo::new(Arc::from("Test"), variants))
+        ResolvedType::enumeration(EnumInfo::new(Arc::from("Test"), variants, Span::DUMMY))
     }
 
     /// An enum with one unit variant, one single-payload variant and one
@@ -1430,7 +1431,7 @@ mod tests {
             ),
         ]);
 
-        ResolvedType::enumeration(EnumInfo::new(Arc::from("Test"), variants))
+        ResolvedType::enumeration(EnumInfo::new(Arc::from("Test"), variants, Span::DUMMY))
     }
 
     #[test]

--- a/src/value.rs
+++ b/src/value.rs
@@ -1413,7 +1413,12 @@ mod tests {
             })
             .collect();
 
-        ResolvedType::enumeration(EnumInfo::new(Arc::from("Test"), variants, Span::DUMMY))
+        ResolvedType::enumeration(EnumInfo::new(
+            Arc::from("Test"),
+            variants,
+            Span::DUMMY,
+            Arc::from([]),
+        ))
     }
 
     /// An enum with one unit variant, one single-payload variant and one
@@ -1431,7 +1436,12 @@ mod tests {
             ),
         ]);
 
-        ResolvedType::enumeration(EnumInfo::new(Arc::from("Test"), variants, Span::DUMMY))
+        ResolvedType::enumeration(EnumInfo::new(
+            Arc::from("Test"),
+            variants,
+            Span::DUMMY,
+            Arc::from([]),
+        ))
     }
 
     #[test]

--- a/src/witness.rs
+++ b/src/witness.rs
@@ -357,6 +357,8 @@ impl crate::ArbitraryOfType for Arguments {
 mod tests {
     use super::*;
     use crate::ast::ElementsJetHinter;
+    #[cfg(feature = "serde")]
+    use crate::error::Span;
     use crate::parse::ParseFromStr;
     #[cfg(feature = "serde")]
     use crate::str::Identifier;
@@ -521,7 +523,8 @@ fn main() {
             .into_iter()
             .map(|name| EnumVariantInfo::new(Identifier::from_str_unchecked(name), Arc::from([])))
             .collect();
-        let action_ty = ResolvedType::enumeration(EnumInfo::new(Arc::from("Action"), variants));
+        let action_ty =
+            ResolvedType::enumeration(EnumInfo::new(Arc::from("Action"), variants, Span::DUMMY));
         let witness_types = WitnessTypes::from(HashMap::from([(
             TemplateProgramWitness::witness_from_str("ACTION"),
             action_ty.clone(),
@@ -562,7 +565,8 @@ fn main() {
             .into_iter()
             .map(|name| EnumVariantInfo::new(Identifier::from_str_unchecked(name), Arc::from([])))
             .collect();
-        let action_ty = ResolvedType::enumeration(EnumInfo::new(Arc::from("Action"), variants));
+        let action_ty =
+            ResolvedType::enumeration(EnumInfo::new(Arc::from("Action"), variants, Span::DUMMY));
         let option_ty = ResolvedType::option(action_ty.clone());
         let tuple_ty = ResolvedType::tuple([
             action_ty.clone(),

--- a/src/witness.rs
+++ b/src/witness.rs
@@ -523,8 +523,12 @@ fn main() {
             .into_iter()
             .map(|name| EnumVariantInfo::new(Identifier::from_str_unchecked(name), Arc::from([])))
             .collect();
-        let action_ty =
-            ResolvedType::enumeration(EnumInfo::new(Arc::from("Action"), variants, Span::DUMMY));
+        let action_ty = ResolvedType::enumeration(EnumInfo::new(
+            Arc::from("Action"),
+            variants,
+            Span::DUMMY,
+            Arc::from([]),
+        ));
         let witness_types = WitnessTypes::from(HashMap::from([(
             TemplateProgramWitness::witness_from_str("ACTION"),
             action_ty.clone(),
@@ -565,8 +569,12 @@ fn main() {
             .into_iter()
             .map(|name| EnumVariantInfo::new(Identifier::from_str_unchecked(name), Arc::from([])))
             .collect();
-        let action_ty =
-            ResolvedType::enumeration(EnumInfo::new(Arc::from("Action"), variants, Span::DUMMY));
+        let action_ty = ResolvedType::enumeration(EnumInfo::new(
+            Arc::from("Action"),
+            variants,
+            Span::DUMMY,
+            Arc::from([]),
+        ));
         let option_ty = ResolvedType::option(action_ty.clone());
         let tuple_ty = ResolvedType::tuple([
             action_ty.clone(),


### PR DESCRIPTION
## Problem

`enum` cannot be used in any program that the driver wraps in a module, which is
every program, since flattening wraps the entry file too. Two checks reject the
declaration: `parse::Module::validate` rejects `enum` inside a `mod` block, and
`forbid_enum_dec_in_deps` rejects `enum` in a dependency file. Both exist because an
enum's identity in the ABI was its bare declared name, which forced the name to be
unique program-wide.

This blocks `enum` in Simplex entirely, and in any multi-file
program.

## Fix

The ABI no longer identifies an enum by its bare name. It identifies it by the path of
the file the enum was declared in, the module chain inside that file, and the full
expanded type.

The path is what makes this work across dependencies, so a consumer knows which file an
enum comes from.

Previous abi for `last_will.simf` file:
``` bash
AbiMeta { witness_types: WitnessTypes({TemplateProgramWitness { inner: Witness("ACTION") }: Action}), param_types: Parameters({}) }
```

Current:
``` bash
AbiOutput { witness_types: {"ACTION": "<path>(::<modules>): Action { Inherit([u8; 64]), ColdSpend([u8; 64]), HotSpend([u8; 64]) }"}, param_types: {} }
```

The `<modules>` segment is omitted when the enum is declared at the top level of its
file; the driver-assigned `unit_N` wrapper is never shown.